### PR TITLE
Missing modules

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -56,6 +56,7 @@ MODULES=yaws \
 	yaws_stats \
 	yaws_vdir \
 	yaws_multipart \
+	yaws_dime.erl \
 	$(BITSMODS)
 
 


### PR DESCRIPTION
Hello.

I found that there are some modules presented in src directory but unreferenced in src/Makefile. In particular, the yaws_dime.erl module. Unlike other unreferenced files this one contains functions which are called in other modules (just grep yaws_dime src/\* ) so this situation is dangerous.

I simply added this file to the $(MODULES) list.
