### PR TITLE
configure was failing to determine Erlang's word size on Linux

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -203,6 +203,7 @@ HAVE_SENDFILE=false
 case "$host_os" in
         *linux*)
            AC_DEFINE(LINUX)
+           AC_LANG(Erlang)
            AC_RUN_IFELSE(
                [AC_LANG_PROGRAM([],[dnl
                            halt(case erlang:system_info(wordsize) of
@@ -253,6 +254,7 @@ case "$host_os" in
            AC_SUBST(FPIC)
            ;;
          *darwin*)
+           AC_LANG(C)
            AC_CHECK_LIB([c],[sendfile],[HAVE_SENDFILE=true])
            case "$host_os" in
                darwin10*)


### PR DESCRIPTION
Apparently https://github.com/klacke/yaws/commit/3cdb6453912e1ea4160dc3c646d2f0ccc500d6c8 doesn't always work well. I have a 64-bit Erlang on a Linux box:

```
  $ erl
  Erlang R14B02 (erts-5.8.3) [source] [64-bit] [smp:4:4] [rq:4] [async-threads:0] [hipe] [kernel-poll:false]

  Eshell V5.8.3  (abort with ^G)
  1> erlang:system_info(wordsize).
  8

  $ uname -a
  Linux agner 2.6.35.4-rscloud #8 SMP Mon Sep 20 15:54:33 UTC 2010 x86_64 GNU/Linux
```

Yet on this system yaws' configure decides it is a 32-bit Erlang:

```
  configure: found 32-bit Erlang
```

I also confirmed it on another local Linux box.

This patch seemingly fixes this problem.
