### PR TITLE
Populate soap_srv_mods field in yaws:setup_gconf/2

### DIFF
--- a/src/yaws.erl
+++ b/src/yaws.erl
@@ -218,7 +218,9 @@ setup_gconf(GL, GC) ->
            id = lkup(id, GL,
                      GC#gconf.id),
            enable_soap = lkup(enable_soap, GL,
-                              GC#gconf.enable_soap)
+                              GC#gconf.enable_soap),
+           soap_srv_mods = lkup(soap_srv_mods, GL,
+                              GC#gconf.soap_srv_mods)
           }.
 
 set_gc_flags([{tty_trace, Bool}|T], Flags) ->


### PR DESCRIPTION
When running in embedded mode, this function is used
to setup the GConf. Currently, the soap_srv_mods field
is not built and is ignored.

This corrects that

Signed-off-by: Essien Ita Essien essiene@gmail.com
