### PR TITLE
Allow to pass options to erlsom (fix issue #65)

### DIFF
--- a/src/yaws_soap_srv.erl
+++ b/src/yaws_soap_srv.erl
@@ -79,9 +79,14 @@ setup(Id, WsdlFile) when is_tuple(Id),size(Id)==2 ->
     Wsdl = yaws_soap_lib:initModel(WsdlFile),
     gen_server:call(?SERVER, {add_wsdl, Id, Wsdl}, infinity).
 
-
-setup(Id, WsdlFile, Prefix) when is_tuple(Id),size(Id)==2 ->
-    Wsdl = yaws_soap_lib:initModel(WsdlFile, Prefix),
+%% PrefixOrOptions can be either a prefix (a String) or a property 
+%% list. It is used to construct the options that are passed to Erlsom
+%% to compile the WSDL file. Passing a string ("Prefix") is equivalent 
+%% to [{prefix, "Prefix"}]. 
+%% If a list of erlsom options is passed, and this does not contain
+%% the {prefix, ...} option, the yaws_soap default ("p") will be used.
+setup(Id, WsdlFile, PrefixOrOptions) when is_tuple(Id),size(Id)==2 ->
+    Wsdl = yaws_soap_lib:initModel(WsdlFile, PrefixOrOptions),
     gen_server:call(?SERVER, {add_wsdl, Id, Wsdl}, infinity).
 
 
@@ -266,7 +271,3 @@ get_model(State, Id) ->
 uinsert({K,_} = E, [{K,_}|T]) -> [E|T];
 uinsert(E, [H|T])             -> [H|uinsert(E,T)];
 uinsert(E, [])                -> [E].
-
-
-
-

--- a/www/soap_intro.yaws
+++ b/www/soap_intro.yaws
@@ -224,7 +224,15 @@ out(A) ->
             "functions above may as well be a local file, and thus written as \"file://....\". "},
            {li, [],
             "When we retrieve a HTTP located file, we will use 'ibrowse' if it exist "
-            "in the code path. Otherwise we will use the OTP 'http' client."}
+            "in the code path. Otherwise we will use the OTP 'http' client."},
+           {li, [], 
+            "The prefix ('foo' in the example above) is passed to erlsom - it is one of erlsom's "
+            "options. If you want to specify other options, you can also pass the regular erlsom "
+	    "options to yaws_soap_lib:initModel/2 and yaws_soap_lib:write_hrl/3. For example, to "
+	    "specify how files that the XSD inside the WSDL refers to via 'include' statements "
+	    "can be retrieved, you can pass it a function GetIncludes/4 by specifying "
+	    "[{include_fun, GetIncludes}]. See the erlsom documentation for other options that you "
+            "could specify."}
           ]}]},
 
        {h2, [], "The SOAP server side"},
@@ -346,7 +354,10 @@ out(A) ->
           ),
 
        {p,[],
-        "Now, in your Yaws shell, setup the Soap server as shown below:"
+        "Now, in your Yaws shell, setup the Soap server as shown below. (If required, for "
+	"example to specify a prefix or a function to retrieve included files, you can specify "
+	"options similar to what we saw above for yaws_soap_lib:initModel/2 and "
+	"yaws_soap_lib:write_hrl/3 , using yaws_soap_srv:setup/3.)" 
         },
 
        box("6> yaws:start_embedded(Docroot,SL,GL).\n"
@@ -395,10 +406,4 @@ out(A) ->
 
 
 </erl>
-
-
-
-
-
-
 


### PR DESCRIPTION
As discussed with Steve. 

I tried to fix issue 65. It is now possible to pass options to erlsom. This includes an option to specify a function to get included XSD files; not having this option caused the problem of the person who logged the issue.

Regards,
Willem
