### PR TITLE
check for Host = undefined in pick_host()

### DIFF
--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -1345,7 +1345,7 @@ pick_sconf(GC, H, Group) ->
 
 %% Compare Host against [] in case caller sends an empty Host header
 pick_host(GC, Host, SCs, Group)
-  when Host == []; SCs == [] ->
+  when Host == []; Host == undefined; SCs == [] ->
     if
         ?gc_pick_first_virthost_on_nomatch(GC) ->
             hd(Group);


### PR DESCRIPTION
We had some problem some months back where it turned out that Host could be 'undefined' in yaws_server:pick_host/4. According to Tobbe, it happened when there was no host header in the http request, if his memory serves him.

   /Richard
