### PR TITLE
fixed warnings about unused imports and export_all

### DIFF
--- a/src/mime_type_c.erl
+++ b/src/mime_type_c.erl
@@ -7,7 +7,8 @@
 
 -module(mime_type_c).
 -author('klacke@hyber.org').
--compile(export_all).
+
+-export([compile/0]).
 
 
 %% this module reads the mime.types file and creates
@@ -95,7 +96,7 @@ gen(T) ->
     {ok, Fd} = file:open("mime_types.erl", [write]),
     io:format(Fd,
               "-module(mime_types). ~n"
-              "-compile(export_all). ~n", []),
+              "-export([t/1, revt/1]). ~n", []),
 
     L = lists:sort(ets:tab2list(T)),
     special(Fd, "yaws", yaws),

--- a/src/yaws_api.erl
+++ b/src/yaws_api.erl
@@ -122,7 +122,7 @@
         ]).
 
 
--import(lists, [map/2, flatten/1, reverse/1]).
+-import(lists, [flatten/1, reverse/1]).
 
 %% these are a bunch of function that are useful inside
 %% yaws scripts

--- a/src/yaws_generated.template
+++ b/src/yaws_generated.template
@@ -10,7 +10,10 @@
 -module(yaws_generated).
 -author('klacke@bluetail.com').
 
--compile(export_all).
+-export([version/0,
+         vardir/0,
+         etcdir/0,
+         is_local_install/0]).
 
 version() -> "%VSN%".
 

--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -49,7 +49,7 @@
          'PATCH'/3]).
 
 -import(lists, [member/2, foreach/2, map/2,
-                flatten/1, flatmap/2, reverse/1]).
+                flatten/1, reverse/1]).
 
 -import(yaws_api, [ehtml_expand/1]).
 


### PR DESCRIPTION
Since you added +Werror to the makeflags (a good thing), I had problems compiling due to some trivial warnings. This patch takes care of that.
