### PR TITLE
Feature/soap12 imports namespaces

### DIFF
--- a/src/yaws_soap12_lib.erl
+++ b/src/yaws_soap12_lib.erl
@@ -593,7 +593,17 @@ ibrowse_request(URL, Action, Request, Options, Headers, ContentType) ->
                               _ ->
                                   [{"SOAPAction", Action} | Headers]
                           end],
-            case ibrowse:send_req(URL, NewHeaders, post, Request, Options) of
+            IbrowseF = case lists:keyfind(ibrowse_timeout, 1, Options) of
+                {_, Timeout} ->
+                    fun() ->
+                        ibrowse:send_req(URL, NewHeaders, post, Request, Options, Timeout)
+                    end;
+                false ->
+                    fun() ->
+                        ibrowse:send_req(URL, NewHeaders, post, Request, Options)
+                    end
+            end,
+            case IbrowseF() of
                 {ok, Status, ResponseHeaders, ResponseBody} ->
                     {ok, list_to_integer(Status), ResponseHeaders, ResponseBody};
                 {error, Reason} ->


### PR DESCRIPTION
- adds handling of schemas included in wsdl files with different than wsdl definitions targetNamespace; there was the issue of always putting the included schema into the wsdl definitions target namespace. As a result the wsdl model is now fixed and generates proper xmls when any yaws_sop_lib12:call is run
- allows for customization of http client library request options as well as specific ibrowse timeout - the latter is needed because ibrowse doesn't provide means to override this specific setting through its options config(the timeout there is a different setting) 
- TODO: abstracting everything but soap xsd differences is needed from yaws_soap_lib & yaws_soap12_lib(the above described changes can be applied to yaws_soap_lib as well where they are now implemented as part of yaws_soap12_lib only). I am willing to help there but unfortunately don't have much time...
