### PR TITLE
Update Makefile and src/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ touch:
 	find . -name '*.erl' -print | xargs touch -m
 
 yaws.plt:
-	dialyzer --build_plt -r ebin src --output_plt yaws.plt \
+	dialyzer --build_plt -r ebin --output_plt yaws.plt \
 	   -r $(ERLDIR)/lib/sasl-$(SASL_VSN) \
 	   -r $(ERLDIR)/lib/kernel-$(KERNEL_VSN) \
 	   -r $(ERLDIR)/lib/stdlib-$(STDLIB_VSN) \
@@ -89,7 +89,7 @@ yaws.plt:
 #   	   -r $(ERLDIR)/lib/ssl-$(SSL_VSN)
 
 dialyzer:	yaws.plt
-	-dialyzer -q --plt yaws.plt -r ebin src > dialyzer_warnings
+	-dialyzer -q --plt yaws.plt -r ebin > dialyzer_warnings
 	diff -U0 known_dialyzer_warnings dialyzer_warnings
 
 .PHONY: test

--- a/src/Makefile
+++ b/src/Makefile
@@ -101,9 +101,7 @@ charset.def:
            echo $(DEFAULT_CHARSET) > ../priv/charset.def; \
 	else rm -f ../priv/charset.def ; touch ../priv/charset.def; fi
 
-mime_type_c.beam: mime_type_c.erl
-
-mime_types.erl: charset.def mime_type_c.beam
+mime_types.erl: charset.def ../ebin/mime_type_c.beam
 	$(ERL) -noshell -pa ../ebin -s mime_type_c generate
 
 debug:


### PR DESCRIPTION
- Targets in `Makefile` of `yaws.plt` and `dialyzer` calls
  dialyzer with two target directories, `ebin` and `src`;
  this causes the error of duplicate modules.
  Checking out the .beam files under `ebin` is sufficient
  for dialyzer; `src` is removed.
- Target `mime_type_c.beam` in `src/Makefile` is
  superfluous and generates a spurious .beam file in
  the `src` directory, so the target is removed.
  Also target `charset.def` in `src/Makefile` should be
  dependent on `../ebin/mime_type_c.beam`, so this is
  also changed from the previous target without the
  directory path.
