### PR TITLE
Fixed PUT method with chunked transfer encoding.

### DIFF
--- a/src/yaws_dav.erl
+++ b/src/yaws_dav.erl
@@ -111,7 +111,7 @@ put(SC, ARG) ->
             try
                 case H#headers.content_length of
                     undefined ->
-                        Chunked = H#headers.transfer_encoding == "chunked",
+                        Chunked = yaws:to_lower(H#headers.transfer_encoding) == "chunked",
                         case H#headers.connection of
                             "close" when Chunked == false->
                                 store_client_data(Fd, CliSock, all, SSL);


### PR DESCRIPTION
Case-insensitivity value matching of Transfer-Encoding header should be used. For example, MacOS Finder uses "Transfer-Encoding: Chunked".

After this fix MacOS Finder can successfully write files on DAV shares.
