### PR TITLE
fix compile of generated mime_types.erl

### DIFF
--- a/src/mime_type_c.erl
+++ b/src/mime_type_c.erl
@@ -57,7 +57,7 @@ generate(ModFile, GInfo, SInfoMap) ->
                       "-export([default_type/0, default_type/1]).~n"
                       "-export([t/1, revt/1]).~n"
                       "-export([t/2, revt/2]).~n~n"
-                      "-include_lib(\"yaws/include/yaws.hrl\").~n~n", []),
+                      "-include(\"yaws.hrl\").~n~n", []),
 
             %% Generate default_type/0, t/1 and revt/1
             io:format(Fd,


### PR DESCRIPTION
In generated mime_types.erl, -include_lib(".../yaws.hrl") fails when building on a bare system, should be -include("yaws.hrl"), in which case it is found in the source tree.
