### PR TITLE
Fix io:format call in yaws_compile.

### DIFF
--- a/src/yaws_compile.erl
+++ b/src/yaws_compile.erl
@@ -311,7 +311,7 @@ new_out_file(Line, C, Tail, GC) ->
     ?Debug("Writing outout file~s~n", [OutFile]),
     {ok, Out} = file:open(OutFile, [write]),
     ok = io:format(Out, "-module(\'~s\').~n-export([out/1]).~n~n", [Module]),
-    ok = io:format(Out, "-yawsfile('" ++ get(yfile) ++ "').~n",[]),
+    ok = io:format(Out, "-yawsfile(\'~s\').~n",[get(yfile)]),
     io:format(Out, "%%~n%% code at line ~w from file ~s~n%%~n",
               [Line, C#comp.infile]),
     io:format(Out, "-import(yaws_api, [f/2, fl/1, postvar/2, queryvar/2])."


### PR DESCRIPTION
Basically, yaws_compile was unable to process items in some "unlucky"
paths on Win32.

NTFS may generate filenames in an MS-DOS compatible format if the
original filename is not compatible with the legacy 8.3 notation;
these filenames often contain tilde characters, which are inserted
(unquoted) in the Format parameter of io:format by the string
concatenation.

These unquoted tilde characters are processed as usual, leading to
a badarg error as the Data parameter is always an empty list.
