### PR TITLE
Support multipart/form-data "name" with backslash at the end, add tests.

### DIFF
--- a/src/yaws_api.erl
+++ b/src/yaws_api.erl
@@ -303,6 +303,8 @@ parse_arg_key([C|Line], Key, Value) ->
 
 parse_arg_value([], Key, Value, _, _) ->
     make_parse_line_reply(Key, Value, []);
+parse_arg_value([$\\,$"], Key, Value, _, _) ->
+    make_parse_line_reply(Key, [$\\|Value], []);
 parse_arg_value([$\\,$"|Line], Key, Value, Quote, Begun) ->
     parse_arg_value(Line, Key, [$"|Value], Quote, Begun);
 parse_arg_value([$"|Line], Key, Value, false, _) ->

--- a/test/eunit/multipart_post_parsing.erl
+++ b/test/eunit/multipart_post_parsing.erl
@@ -217,8 +217,8 @@ escaped_parse_test() ->
     %% Support unescaped backslash (Firefox, Chrome, Konqueror, IE).
     "a\\b" = get_unescaped_name("a\\b"),
     "a\\\\b" = get_unescaped_name("a\\\\b"),
-    %% Current behaviour when backslash is last character.
-    "a\"" = get_unescaped_name("a\\"),
+    %% Support backslash at the end of name (for simple form values).
+    "a\\" = get_unescaped_name("a\\"),
     ok.
 
 mk_arg(Data) ->


### PR DESCRIPTION
While writing a multipart/form-data encoder and using yaws_api:parse_multipart_post/1 to test it against, I noticed that it behaves strangely when a backslash is the last character in the "name" field.

This patch corrects this, and adds tests for this and other "strange" cases.
