### PR TITLE
Simple patch for a crash that occurs when yaws cannot find a file's mime-type.

### DIFF
--- a/src/yaws.erl
+++ b/src/yaws.erl
@@ -1457,11 +1457,15 @@ make_last_modified_header(FI) ->
 
 make_expires_header(MimeType0, FI) ->
     SC = get(sc),
-    [MimeType1|_] = yaws:split_sep(MimeType0, $;), %% Remove charset
+    case yaws:split_sep(MimeType0, $;) of
+      [] ->
+          {undefined, undefined};
+      [MimeType1|_] ->
     case lists:keyfind(MimeType1, 1, SC#sconf.expires) of
         {MimeType1, Type, TTL} -> make_expires_header(Type, TTL, FI);
         false                  -> {undefined, undefined}
-    end.
+    end
+end.
 
 
 make_expires_header(access, TTL, _FI) ->


### PR DESCRIPTION
=ERROR REPORT==== 21-Feb-2013::12:02:48 ===
Yaws process died: {{badmatch,[]},
                    [{yaws,make_expires_header,2,
                           [{file,"src/yaws.erl"},{line,1460}]},
                     {yaws,outh_serialize,0,
                           [{file,"src/yaws.erl"},{line,1647}]},
                     {yaws_server,deliver_accumulated,4,
                                  [{file,"src/yaws_server.erl"},{line,3722}]},
                     {yaws_server,handle_ut,4,
                                  [{file,"src/yaws_server.erl"},{line,2188}]},
                     {yaws_server,aloop,4,
                                  [{file,"src/yaws_server.erl"},{line,1175}]},
                     {yaws_server,acceptor0,2,
                                  [{file,"src/yaws_server.erl"},{line,1016}]},
                     {proc_lib,init_p_do_apply,3,
                               [{file,"proc_lib.erl"},{line,227}]}]}

The crash occurs when Yaws can't find a corresponding mime-type
