### PR TITLE
Try to make the log directory if it doesn't exist

### DIFF
--- a/src/yaws_config.erl
+++ b/src/yaws_config.erl
@@ -662,7 +662,7 @@ fload(FD, globals, GC, C, Cs, Lno, Chars) ->
                     ok;
                 false ->
                     % try to make the log directory if it doesn't exist
-                    file:make_dir(Dir)
+                    yaws:mkdir(Dir)
             end,
             case is_dir(Dir) of
                 true ->


### PR DESCRIPTION
This patch makes Yaws try to create the log directory if it doesn't exist.  Pretty self explanatory.  It's useful when doing application testing, where I can spin up many instances of Yaws in different potentially unknown base directories, without having to figure out how to make the log directory first.

I based this patch off of the yaws-1.96 tag for my own uses, but it applies cleanly to the current HEAD.
