### PR TITLE
Fix configure check for file:sendfile/5

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -320,7 +320,7 @@ esac
 
 AC_ARG_ENABLE(sendfile, AS_HELP_STRING([--disable-sendfile], [disables use of sendfile system call]),
                         [ test "$enableval" = no && HAVE_YAWS_SENDFILE=false ])
-file_sendfile=`"${ERL}" -noshell -eval 'code:load_file(file), io:format("~p~n",[[erlang:function_exported(file,sendfile,5)]]), erlang:halt().' | tail -1`
+file_sendfile=`"${ERL}" -noshell -nostick -eval 'code:load_file(file), io:format("~p~n",[[erlang:function_exported(file,sendfile,5)]]), erlang:halt().' | tail -1`
 if test "$file_sendfile" = true -a \
    '(' $ERTS_MAJOR -gt 5 -o \
      '(' $ERTS_MAJOR -eq 5 -a $ERTS_MINOR -gt 9 ')' -o \
@@ -331,7 +331,7 @@ fi
 AC_SUBST(HAVE_YAWS_SENDFILE)
 
 HAVE_CRYPTO_HASH=false
-crypto_hash=`"${ERL}" -noshell -eval 'code:load_file(crypto), io:format("~p~n",[[erlang:function_exported(crypto,hash,2)]]), erlang:halt().' | tail -1`
+crypto_hash=`"${ERL}" -noshell -nostick -eval 'code:load_file(crypto), io:format("~p~n",[[erlang:function_exported(crypto,hash,2)]]), erlang:halt().' | tail -1`
 if test "$crypto_hash" = true; then
    HAVE_CRYPTO_HASH=true
    AC_MSG_NOTICE(found crypto:hash/2)


### PR DESCRIPTION
After 98db40b the check outputs:

```
$ erl -noshell -eval 'code:load_file(file), io:format("~p~n",[[erlang:function_exported(file,sendfile,5)]]), erlang:halt().'
[true]

=ERROR REPORT==== 25-Jun-2013::09:40:51 ===
Can't load module that resides in sticky dir
```

The error is prevented by the "-nostick" option.
