### PR TITLE
Fix runtime error on OpenBSD 5.3

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -270,7 +270,7 @@ case "$host_os" in
                     AC_SUBST(BSDI)
                     ;;
            esac
-           LD_SHARED="ld -Bshareable"
+           LD_SHARED="$CC -shared"
            AC_SUBST(LD_SHARED)
            FPIC=-fpic
            AC_SUBST(FPIC)


### PR DESCRIPTION
Hi,

This pull request fixes the following error on OpenBSD 5.3:

```
/usr/local/lib/erlang/erts-5.10.3/bin/beam:/tmp/yaws/priv/lib/setuid_drv.so: undefined symbol '__guard_local'
=ERROR REPORT==== 20-May-2013::03:37:28 ===
Failed to load setuid_drv (from "/tmp/yaws/priv/lib") : "Cannot load specified object".
```

It follows advice from http://erlang.org/pipermail/erlang-questions/2013-May/073837.html and replaces the use of 'ld' with 'gcc' (through '$CC') in LD_SHARED.

I tested the patch on both OpenBSD 5.3 and FreeBSD 9 and I _think_ it should be safe for the other BSDs (although I didn't test them all).

Thanks,
Francis
