### PR TITLE
yaws_session_server:print_sessions/0 not working due incorrect message

### DIFF
--- a/src/yaws_session_server.erl
+++ b/src/yaws_session_server.erl
@@ -216,8 +216,8 @@ handle_call(stop, From, State) ->
 %%          {noreply, State, Timeout} |
 %%          {stop, Reason, State}            (terminate/2 is called)
 %%----------------------------------------------------------------------
-handle_cast(print_session, #state{backend = Backend} = State) ->
-    Ss = Backend:list(Backend),
+handle_cast(print_sessions, #state{backend = Backend} = State) ->
+    Ss = Backend:list(),
     io:format("** ~p sessions active ~n~n", [length(Ss)]),
     N = gnow(),
     lists:foreach(fun(S) ->


### PR DESCRIPTION
Hello,

yaws_session_server:print_sessions/0  doesn't work due incorrect message, additionally Backend:list/1  doesn't exists, the correct one is Backend:list/0

Regards.
