### PR TITLE
Incorrect X-Forwarded-For header

### DIFF
--- a/src/yaws.erl
+++ b/src/yaws.erl
@@ -2174,8 +2174,15 @@ http_collect_headers(CliSock, Req, H, SSL, Count) when Count < 1000 ->
                                  H#headers{authorization = parse_auth(X)},
                                  SSL, Count+1);
         {ok, {http_header, _Num, 'X-Forwarded-For', _, X}} ->
-            http_collect_headers(CliSock, Req, H#headers{x_forwarded_for=X},
-                                 SSL, Count+1);
+            case H#headers.x_forwarded_for of
+                undefined ->
+                    http_collect_headers(CliSock, Req, H#headers{x_forwarded_for=X},
+                                        SSL, Count+1);
+                PrevXF ->
+                    NewXF = lists:flatten([PrevXF,", ",X]),
+                    http_collect_headers(CliSock, Req, H#headers{x_forwarded_for=NewXF},
+                                        SSL, Count+1)
+            end;
         {ok, http_eoh} ->
             H;
 


### PR DESCRIPTION
When X-Forwarded-For header appears multiple times in request only
the last value is present in yaws_api:headers_x_forwarded_for/1

The RFC 2616, section 4.2 permits multiple headers with same name
as an equivalent of one header with comma separated list of values.

http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2

Pound loadbalancer ( http://www.apsis.ch/pound ) repeats the header.
