### PR TITLE
Add note about running rebar get-deps before rebar compile

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,3 @@
-
 This is yaws, a webserver for dynamic content written in Erlang.
 
 
@@ -19,6 +18,8 @@ To build and install
 2. You can build using rebar:
 
 # rebar compile
+*note* if you get a failure that "Dependency not available", try running
+# rebar get-deps
 
   or via configure and make:
 


### PR DESCRIPTION
I was trying to install with rebar compile and kept getting the failure that the ibrowse dependency wasn't available. Once I did a rebar get-deps, the rebar compile seemed to have gone through.
