### PR TITLE
Add README.osx for instructions on installing on OSX using Homebrew

### DIFF
--- a/README.osx
+++ b/README.osx
@@ -1,0 +1,8 @@
+# Homebrew on OSX
+
+If you develop on OSX (Snow Leopard, Lion, Mountain Lion), the yaws formula
+has been fixed for Erlang R16B01 and above users. To install please run:
+`brew install yaws`. To install the HEAD using Homebrew run:
+`brew install --HEAD yaws`.
+
+This was introduced with [this pull request merge](https://github.com/mxcl/homebrew/pull/23076).


### PR DESCRIPTION
I just had a fix (for Erlang R16B01 and above) I submitted for the yaws formula in Homebrew merged from pull request mxcl/homebrew#23076 to master earlier today. This is to document the ability to install on OSX this way. The Homebrew formula uses an almost identical process to that defined in the README.
