### PR TITLE
rebar compile eunit compile_only=true fails for yaws

### DIFF
--- a/test/t11/src/srcdir_test.erl
+++ b/test/t11/src/srcdir_test.erl
@@ -1,5 +1,7 @@
 -module(srcdir_test).
 
+-ifdef(SRCDIR_VERSION).
+
 -export([out/1]).
 
 -include("srcdir_test.hrl").
@@ -8,4 +10,4 @@ out(_Arg) ->
     Content = ?SRCDIR_VERSION,
     [{status, 200}, {content, "text/plain", Content}].
 
-
+-endif. %% -ifdef(SRCDIR_VERSION).


### PR DESCRIPTION
Changes to allow yaws to be compiled by rebar for eunit testing.  This change is helpful when embedding yaws as a dependency of an Erlang application.

NOTE: One or more eunit tests will still fail when run via rebar.
