### PR TITLE
Change binary conversion function in yaws_rpc in order to deal with unic...

### DIFF
--- a/src/yaws_rpc.erl
+++ b/src/yaws_rpc.erl
@@ -115,7 +115,7 @@ parse_request(Args) ->
 handle_payload(Args, Handler, Type) ->
     RpcType = recognize_rpc_type(Args),
     %% haXe parameters are URL encoded
-    PL = binary_to_list(Args#arg.clidata),
+    PL = unicode:characters_to_list(Args#arg.clidata),
     {Payload,DecodedStr} =
         case RpcType of
             T when T==haxe; T==json ->


### PR DESCRIPTION
...ode characters.

Json text is supposed to be encoded in Unicode, and seems that binary_to_list messes up the characters if they are above 255??
