### PR TITLE
Update CFLAGS

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -16,7 +16,7 @@ ifeq ($(HAVE_SENDFILE),true)
 	PRIV_FILES += ../priv/lib/yaws_sendfile_drv.$(DLL)
 endif
 
-CFLAGS += -I"${ERLDIR}/usr/include"
+CFLAGS += -I"${ERLDIR}/erts/emulator/beam/" -I"${ERLDIR}/erts/include/x86_64-unknown-linux-gnu/"  
 
 #
 # Targets


### PR DESCRIPTION
For me CFLAGS += -I"${ERLDIR}/usr/include" was referencing to a directory which didn't exists . Make command was showing error "unable to find erl_driver.h" . Changed CFLAGS += -I"${ERLDIR}/ to CFLAGS += -I"${ERLDIR}/erts/emulator/beam/" -I"${ERLDIR}/erts/include/x86_64-unknown-linux-gnu/"  now make command works fine.
