### PR TITLE
exit the yaws_ticker process together with the process receiving the message

### DIFF
--- a/src/yaws.erl
+++ b/src/yaws.erl
@@ -839,6 +839,7 @@ ticker(Time, Msg) ->
 ticker(Time, To, Msg ) ->
     spawn_link(fun() ->
                        process_flag(trap_exit, true),
+                       erlang:monitor(process, To),
                        yaws_ticker:ticker(Time, To, Msg)
                end).
 

--- a/src/yaws_ticker.erl
+++ b/src/yaws_ticker.erl
@@ -9,6 +9,8 @@
 ticker(Time, To, Msg) ->
     receive
         {'EXIT', _} ->
+            exit(normal);
+        {'DOWN', _MonitorRef, process, To, _Info1} ->
             exit(normal)
     after Time ->
             To ! Msg


### PR DESCRIPTION
there is no point in keeping the yaws_ticker if the message receiver died
-> monitor the process receiving the message and react on the appropriate 'DOWN' message
