### PR TITLE
IPv6 address parsing + IPv6 lookup for FastCGI and reverse proxy

### DIFF
--- a/doc/yaws.tex
+++ b/doc/yaws.tex
@@ -3118,6 +3118,13 @@ The following directives are allowed inside a server definition.
               in a server part using this directive, then it is replaced. Else
               it is kept.
 
+\item        \verb+nslookup_pref = [inet | inet6]+ ---
+              For fcgi servers and revproxy URLs, define the name
+              resolution preference. For example, to perform only IPv4
+              name resolution, use \textit{[inet]}. To do both IPv4
+              and IPv6 but try IPv6 first, use \textit{[inet6, inet]}.
+              Default value is \textit{[inet]}.
+
 \item        \verb+<ssl>  .... </ssl>+
                This begins and ends an SSL configuration for this server. It's
                possible to virthost several SSL servers on the same IP given

--- a/include/yaws.hrl
+++ b/include/yaws.hrl
@@ -109,7 +109,8 @@
           ysession_mod = yaws_session_server, % storage module for ysession
           acceptor_pool_size = 8,             % size of acceptor proc pool
 
-          mime_types_info                     % undefined | #mime_types_info{}
+          mime_types_info,                    % undefined | #mime_types_info{}
+          nslookup_pref = [inet]              % [inet | inet6]
          }).
 
 -record(ssl, {

--- a/man/yaws.conf.5
+++ b/man/yaws.conf.5
@@ -982,6 +982,13 @@ mapping is defined in the global part and redefined in a server part using this
 directive, then it is replaced. Else it is kept.
 
 .TP
+\fBnslookup_pref = [inet | inet6]\fR
+For fcgi servers and revproxy URLs, define the name resolution
+preference. For example, to perform only IPv4 name resolution, use
+[inet]. To do both IPv4 and IPv6 but try IPv6 first, use [inet6, inet].
+Default value is [inet].
+
+.TP
 \fB<ssl> ... </ssl>\fR
 This begins and ends an SSL configuration for this server.  It's possible to
 virthost several SSL servers on the same IP given that they all share the same

--- a/src/yaws_config.erl
+++ b/src/yaws_config.erl
@@ -1130,6 +1130,14 @@ fload(FD, globals, GC, C, Cs, Lno, Chars) ->
                 {error, Str} ->
                     {error, ?F("~s at line ~w", [Str, Lno])}
             end;
+        ["nslookup_pref", '=' | Pref] ->
+            case parse_nslookup_pref(Pref) of
+                {ok, Families} ->
+                    fload(FD, globals, GC#gconf{nslookup_pref = Families},
+                          C, Cs, Lno+1, Next);
+                {error, Str} ->
+                    {error, ?F("~s at line ~w", [Str, Lno])}
+            end;
 
 
         ['<', "server", Server, '>'] ->  %% first server
@@ -2595,6 +2603,45 @@ parse_mime_types_info(add_charsets, NewCharsets, Info) ->
         {ok, Charsets} -> {ok, Info#mime_types_info{charsets=Charsets}};
         Error          -> Error
     end.
+
+
+parse_nslookup_pref(Pref) ->
+    parse_nslookup_pref(Pref, []).
+
+parse_nslookup_pref(Empty, []) when Empty == [] orelse Empty == ['[', ']'] ->
+    %% Get default value, if nslookup_pref = [].
+    {ok, yaws:gconf_nslookup_pref(#gconf{})};
+parse_nslookup_pref([C, Family | Rest], Result)
+  when C == '[' orelse C == ',' ->
+    case Family of
+        "inet" ->
+            case lists:member(inet, Result) of
+                false -> parse_nslookup_pref(Rest, [inet | Result]);
+                true  -> parse_nslookup_pref(Rest, Result)
+            end;
+        "inet6" ->
+            case lists:member(inet6, Result) of
+                false -> parse_nslookup_pref(Rest, [inet6 | Result]);
+                true  -> parse_nslookup_pref(Rest, Result)
+            end;
+        _ ->
+            case Result of
+                [PreviousFamily | _] ->
+                    {error, ?F("Invalid nslookup_pref: invalid family or "
+                        "token '~s', after family '~s'",
+                        [Family, PreviousFamily])};
+                [] ->
+                    {error, ?F("Invalid nslookup_pref: invalid family or "
+                        "token '~s'", [Family])}
+            end
+    end;
+parse_nslookup_pref([']'], Result) ->
+    {ok, lists:reverse(Result)};
+parse_nslookup_pref([Invalid | _], []) ->
+    {error, ?F("Invalid nslookup_pref: unexpected token '~s'", [Invalid])};
+parse_nslookup_pref([Invalid | _], [Family | _]) ->
+    {error, ?F("Invalid nslookup_pref: unexpected token '~s', "
+        "after family '~s'", [Invalid, Family])}.
 
 
 parse_redirect(Path, [Code, URL], Mode, Lno) ->

--- a/src/yaws_revproxy.erl
+++ b/src/yaws_revproxy.erl
@@ -574,24 +574,20 @@ connect(URL) ->
     end.
 
 do_connect(URL) ->
-    InetType = if
-                   is_tuple(URL#url.host), size(URL#url.host) == 8 -> [inet6];
-                   true -> []
-               end,
     Opts = [
             binary,
             {packet,    raw},
             {active,    false},
             {recbuf,    8192},
             {reuseaddr, true}
-           ] ++ InetType,
+           ],
     case URL#url.scheme of
         http  ->
             Port = case URL#url.port of
                        undefined -> 80;
                        P         -> P
                    end,
-            case gen_tcp:connect(URL#url.host, Port, Opts) of
+            case yaws:tcp_connect(URL#url.host, Port, Opts) of
                 {ok, S} -> {ok, S, nossl};
                 Err     -> Err
             end;
@@ -600,7 +596,7 @@ do_connect(URL) ->
                        undefined -> 443;
                        P         -> P
                    end,
-            case ssl:connect(URL#url.host, Port, Opts) of
+            case yaws:ssl_connect(URL#url.host, Port, Opts) of
                 {ok, S} -> {ok, S, ssl};
                 Err     -> Err
             end;

--- a/test/conf/revproxyconf.conf
+++ b/test/conf/revproxyconf.conf
@@ -110,6 +110,7 @@ use_fdsrv = false
         arg_rewrite_mod = rewritetest
         revproxy = /revproxy1 http://localhost:8001
         revproxy = /revproxy2 http://localhost:8002
+        revproxy = /revproxy3 http://[::1]:8006
 </server>
 
 <server localhost>
@@ -156,4 +157,12 @@ use_fdsrv = false
         revproxy = /revproxy1 http://localhost:8002 intercept_mod intercept1
         revproxy = /revproxy2 http://localhost:8002 intercept_mod intercept2
         revproxy = /revproxy3 http://localhost:8002 intercept_mod intercept3
+</server>
+
+<server localhost>
+        port = 8006
+        listen = ::
+        listen_backlog = 512
+        deflate = false
+        docroot = %YTOP%/test/t4/www1
 </server>

--- a/test/t4/app_test.erl
+++ b/test/t4/app_test.erl
@@ -33,6 +33,7 @@ start() ->
         test_failed_resp_interception_revproxy(),
         test_good_interception_revproxy(),
         test_fwdproxy(),
+        test_ipv6_address(),
         ok
     catch
         Error:Reason ->
@@ -255,6 +256,14 @@ test_fwdproxy() ->
 
     ?line {ok, "200", _, Body2} = ibrowse:send_req(Uri2, [], get, [], Opts),
     ?line Res = Body2,
+    ok.
+
+test_ipv6_address() ->
+    io:format("revproxy_url_ipv6\n", []),
+    Uri = "http://localhost:8000/revproxy3/hello.txt",
+    Res = "Hello, World!\n",
+
+    ?line {ok, "200", _, _} = ibrowse:send_req(Uri, [], get),
     ok.
 
 recv_hdrs(Sock) ->


### PR DESCRIPTION
This pull request contains two commits to improve IPv6 support for communication between Yaws and FastCGI backends/reverse proxies:
1. Support IPv6 address in reverse proxy URLs and as FastCGI server names, using the `[...]` syntax.
2. Allow the user to choose how FastCGI or reverse proxy server names are resolved and connections are made by setting the list of address families to try (e.g. `[inet6, inet]` if he wants IPv6 first; `[inet]` remains the default to keep the current behavior).

We need this to play with HHVM: on Linux, we set the `net.ipv6.bindv6only` sysctl to `1` and, in this case, HHVM only listen on `::1`, not `127.0.0.1`. It appears to not be configurable.
