### PR TITLE
yaws_api: Make end tags HTML5-compatible in ehtml_expand

### DIFF
--- a/test/eunit/ehtml_test.erl
+++ b/test/eunit/ehtml_test.erl
@@ -6,6 +6,21 @@
 
 -export([mfa_fun/1, nested_mfa_fun/1, nested_mfa_attr_fun/1]).
 
+void_element_test() ->
+    %% No end tag (</tag>) for void elements in HTML5.
+    {ehtml, E1} = {ehtml, [{img, [{src, "foo.png"}, {alt, "foo"}]}]},
+    Img = "<img src=\"foo.png\" alt=\"foo\" />",
+    Img = lists:flatten(yaws_api:ehtml_expand(E1)),
+    {ehtml, E2} = {ehtml, [{br}]},
+    Br = "<br />",
+    Br = lists:flatten(yaws_api:ehtml_expand(E2)).
+
+non_void_element_test() ->
+    %% No self-closing syntax (/>) for non-void elements in HTML5.
+    {ehtml, E} = {ehtml, [{p}]},
+    P = "<p></p>",
+    P = lists:flatten(yaws_api:ehtml_expand(E)).
+
 get_title() ->
     "Funtest Title".
 


### PR DESCRIPTION
Currently, HTML generated by Yaws ehtml does not validate correctly as
HTML5 (e.g. using http://validator.w3.org/). The reason is that in HTML5
"void elements" like `<br>` must not have a closing end tag:

Forbidden: `<br></br>`
Allowed: `<br>`
Allowed (and also valid XHTML): `<br />`

Also, since the self-closing tag syntax ("/>") is simply ignored in
HTML5, some elements must have an end tag:

Forbidden: `<p />`
Allowed:`<p></p>`

This patch fixes both issues and also adds tests.

References:
- http://stackoverflow.com/questions/10598501/closing-tags-in-html5
- http://stackoverflow.com/questions/1946426/html-5-is-it-br-br-or-br
- http://www.w3.org/TR/html-markup/syntax.html#void-element
