### PR TITLE
Fix wiki app file encoding problem

### DIFF
--- a/applications/wiki/src/wiki.erl
+++ b/applications/wiki/src/wiki.erl
@@ -1,4 +1,5 @@
 %    -*- Erlang -*-
+%    coding: utf-8
 %    File:        wiki.erl  (~jb/work/wiki/src/wiki.erl)
 %    Author:    Joe Armstrong
 %    Author:        Johan Bevemyr


### PR DESCRIPTION
applications/wiki/src/wiki.erl:
    added encoding directive to correctly compile
    when configured with utf-8 encoding
