### PR TITLE
Fix ssl protocol version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -239,6 +239,20 @@ fi
 AM_CONDITIONAL(HAVE_SSL_HONOR_CIPHER_ORDER, [test "x$HAVE_SSL_HONOR_CIPHER_ORDER" = "xtrue"])
 AC_SUBST(HAVE_SSL_HONOR_CIPHER_ORDER)
 
+dnl Check for support of versions opt in SSL connect and listen (ERTS >= 5.10.2)
+AC_MSG_CHECKING([for support of versions opt in SSL connect and listen])
+AX_COMPARE_VERSION([${ERLANG_ERTS_VER}], [ge], [5.10.2],
+    [ssl_versions_opt="yes"],
+    [ssl_versions_opt="no"])
+AC_MSG_RESULT([${ssl_versions_opt}])
+
+HAVE_SSL_VERSIONS_OPT=false
+if test "x${ssl_versions_opt}" = "xyes"; then
+        HAVE_SSL_VERSIONS_OPT=true
+fi
+AM_CONDITIONAL(HAVE_SSL_VERSIONS_OPT, [test "x$HAVE_SSL_VERSIONS_OPT" = "xtrue"])
+AC_SUBST(HAVE_SSL_VERSIONS_OPT)
+
 dnl Determine directories for installation.
 if test "x${prefix}" != "xNONE" -a "x${ERLANG_INSTALL_LIB_DIR}" = "x"; then
         dnl Under $prefix

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -101,7 +101,13 @@ ErlOpts6 = if
                true               -> ErlOpts5
            end,
 
-HaveSendFile = lists:keymember('HAVE_SENDFILE', 3, ErlOpts6),
+%% Check for support of versions opt in SSL connect and listen (ERTS >= 5.10.2)
+ErlOpts7 = if
+               ErtsVsn >= {5,10,2} -> ErlOpts6 ++ [{d,'HAVE_SSL_VERSIONS_OPT'}];
+               true                -> ErlOpts6
+           end,
+
+HaveSendFile = lists:keymember('HAVE_SENDFILE', 3, ErlOpts7),
 {PortEnv1, PortSpecs1} =
     if
         HaveSendFile ->
@@ -113,7 +119,7 @@ HaveSendFile = lists:keymember('HAVE_SENDFILE', 3, ErlOpts6),
             {PortEnv0, PortSpecs0}
     end,
 
-Cfg1 = lists:keyreplace(erl_opts,   1, Cfg0, {erl_opts,   ErlOpts6}),
+Cfg1 = lists:keyreplace(erl_opts,   1, Cfg0, {erl_opts,   ErlOpts7}),
 Cfg2 = lists:keyreplace(port_env,   1, Cfg1, {port_env,   PortEnv1}),
 Cfg3 = lists:keyreplace(port_specs, 1, Cfg2, {port_specs, PortSpecs1}),
 Cfg3.

--- a/src/yaws.erl
+++ b/src/yaws.erl
@@ -67,7 +67,8 @@
          ssl_ciphers/1, ssl_ciphers/2,
          ssl_cachetimeout/1, ssl_cachetimeout/2,
          ssl_secure_renegotiate/1, ssl_secure_renegotiate/2,
-         ssl_honor_cipher_order/1, ssl_honor_cipher_order/2]).
+         ssl_honor_cipher_order/1, ssl_honor_cipher_order/2,
+         ssl_versions_opt/1]).
 
 -export([new_deflate/0,
          deflate_min_compress_size/1, deflate_min_compress_size/2,
@@ -377,6 +378,16 @@ ssl_secure_renegotiate  (S, Bool)    -> S#ssl{secure_renegotiate   = Bool}.
 ssl_honor_cipher_order  (S, Bool)    -> S#ssl{honor_cipher_order   = Bool}.
 -else.
 ssl_honor_cipher_order  (S, _)       -> S.
+-endif.
+
+-ifdef(HAVE_SSL_VERSIONS_OPT).
+ssl_versions_opt(_SSL) ->
+    ok.
+-else.
+ssl_versions_opt(#ssl{protocol_version = undefined} = _SSL) ->
+    ok;
+ssl_versions_opt(#ssl{protocol_version = ProtocolVersion} = _SSL) ->
+    application:set_env(ssl, protocol_version, ProtocolVersion).
 -endif.
 
 setup_ssl(SL, DefaultSSL) ->

--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -83,7 +83,6 @@
 -define(elog(X,Y), error_logger:info_msg("*elog ~p:~p: " X,
                                          [?MODULE, ?LINE | Y])).
 
-
 start_link(A) ->
     gen_server:start_link({local, yaws_server}, yaws_server, A, []).
 
@@ -453,6 +452,7 @@ do_listen(GC, SC) ->
         undefined ->
             {nossl, undefined, gen_tcp_listen(SC#sconf.port, listen_opts(SC))};
         SSL ->
+            yaws:ssl_versions_opt(SSL),
             {ssl, certinfo(SSL),
              ssl_listen(SC#sconf.port, ssl_listen_opts(GC, SC, SSL))}
     end.


### PR DESCRIPTION
This PR tackles two interrelated SSL issues:
- the most important one: starting yaws in embedded mode was ignoring the protocol_version
- given that the first issue is now fixed, application:set_env is only used for <R16B01 where the ssl app was ignoring versions on `ssl:connect` and `ssl:listen`. Reference http://erlang.org/pipermail/erlang-questions/2014-October/081388.html . I am not aware of another reason why `application:set_env` would be preferred/required
