### PR TITLE
Fix guard and missing call dialyzer warnings

### DIFF
--- a/known_dialyzer_warnings
+++ b/known_dialyzer_warnings
@@ -11,4 +11,3 @@ yaws_ctl.erl:\d+: Function debug_dump/1 has no local return
 yaws_ctl.erl:\d+: Function stats/1 has no local return
 yaws_ctl.erl:\d+: Function running_config/1 has no local return
 yaws_revproxy.erl:\d+: The pattern 'true' can never match the type 'false'
-yaws_server.erl:\d+: Guard test is_binary\(B :: string\(\)\) can never succeed

--- a/src/yaws_dynopts.erl
+++ b/src/yaws_dynopts.erl
@@ -182,9 +182,25 @@ http_uri_parse(Uri) ->
 
 safe_relative_path(File, Cwd) ->
     case have_safe_relative_path() of
-        true -> (fun filelib:safe_relative_path/2)(File, Cwd);
+        true -> filelib_safe_relative_path_2(File, Cwd);
         false -> yaws:safe_rel_path(File, Cwd)
     end.
+
+%% Make dialyzer happy, don't call filelib:safe_relative_path/2 for OTP < 23.
+-ifdef(OTP_RELEASE).
+  -if(?OTP_RELEASE >= 23).
+filelib_safe_relative_path_2(File, Cwd) ->
+    (fun filelib:safe_relative_path/2)(File, Cwd).
+  -else.
+%% This will never happen, but fallback if it happens anyway.
+filelib_safe_relative_path_2(File, Cwd) ->
+    yaws:safe_rel_path(File, Cwd).
+  -endif.
+-else.
+%% This will never happen, but fallback if it happens anyway.
+filelib_safe_relative_path_2(File, Cwd) ->
+    yaws:safe_rel_path(File, Cwd).
+-endif.
 
 is_greater         (Vsn1, Vsn2) -> compare_version(Vsn1, Vsn2) == greater.
 is_less            (Vsn1, Vsn2) -> compare_version(Vsn1, Vsn2) == less.

--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -5162,8 +5162,6 @@ maybe_set_page_options() ->
     end.
 
 %% TODO move this to yaws_dynopts and use string:trim/3 where available
-trim_front(B, Chars) when is_binary(B) ->
-    list_to_binary(trim_front(binary_to_list(B), Chars));
 trim_front([], _Chars) -> [];
 trim_front(Str=[C|S], Chars) ->
     case lists:member(C, Chars) of


### PR DESCRIPTION
yaws_dynopts.erl:185: Call to missing or unexported function filelib:safe_relative_path/2
yaws_server.erl:5253: Guard test is_binary(B::string()) can never succeed