### PR TITLE
Make response for OPTIONS * configurable

### DIFF
--- a/doc/yaws.tex
+++ b/doc/yaws.tex
@@ -3801,6 +3801,19 @@ protocol_version = tlsv1.3, tlsv1.2, tlsv1.1, tlsv1
               Note that extra response headers do not apply to
               responses returned directly by any
               \verb+DispatchModule+.
+
+\item       \verb+options_asterisk_methods = Methods+ ---
+              By default OPTIONS requests towards the * target responds with
+              400 Bad Request.
+
+              Setting the \verb+options_asterisk_methods = Methods+ to a comma
+              separated string with HTTP methods, makes Yaws respond with HTTP
+              200 and an Allow header with the configured \verb+Methods+.
+
+              Valid methods are:
+\begin{verbatim}
+GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH
+\end{verbatim}
 \end{itemize}
 
 \section{Directives included from .yaws\_auth files}

--- a/include/yaws.hrl
+++ b/include/yaws.hrl
@@ -265,7 +265,8 @@
           mime_types_info,              % undefined | #mime_types_info{}
                                         % if undefined, global config is used
           dispatch_mod,                 % custom dispatch module
-          extra_response_headers = []   % configured extra response headers
+          extra_response_headers = [],  % configured extra response headers
+          options_asterisk_methods = [] % OPTIONS * Allow header, [] -> HTTP 400
          }).
 
 

--- a/testsuite/main_SUITE_data/templates/yaws.conf
+++ b/testsuite/main_SUITE_data/templates/yaws.conf
@@ -97,3 +97,10 @@ keepalive_timeout              = 10000
             extramod = extra_resp_hdrs
         </extra_response_headers>
 </server>
+
+<server localhost>
+        listen = 127.0.0.1
+        port = $yaws_port9$
+        docroot = $wwwdir$
+        options_asterisk_methods = GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH
+</server>


### PR DESCRIPTION
Previously the response to OPTIONS * was hardcoded to send HTTP 200 and
the header Allow: GET, HEAD, OPTIONS, PUT, POST, DELETE.

This change adds the options_asterisk_methods setting in the sconf for a
list of custom HTTP methods allowed for OPTIONS *. By default the list
is empty, and Yaws sends an HTTP 400 Bad Request. If
options_asterisk_methods contains HTTP methods, Yaws responds to
OPTIONS * with HTTP 200 and an Allow header with the contents.

An additional knee-jerk fix was to add the Date header to
yaws_server:deliver_xxx/5. According to RFC 7321, Section 7.1.1.2. Date,
this header MAY be sent for 1xx and 5xx responses and MUST be sent
otherwise.