### PR TITLE
Fix options_asterisk_methods test and conf parsing

### DIFF
--- a/src/yaws_config.erl
+++ b/src/yaws_config.erl
@@ -1366,8 +1366,6 @@ fload(FD, options_asterisk_methods, GC, C, Lno, Chars) ->
         [Methods] ->
             C1 = C#sconf{options_asterisk_methods = Methods},
             fload(FD, options_asterisk_methods, GC, C1, Lno+1, ?NEXTLINE);
-        ['<', "/options_asterisk_methods", '>'] ->
-            fload(FD, server, GC, C, Lno+1, ?NEXTLINE);
         [H|T] ->
             {error, ?F("Unexpected input ~p at line ~w", [[H|T], Lno])};
         Err ->

--- a/testsuite/main_SUITE.erl
+++ b/testsuite/main_SUITE.erl
@@ -139,7 +139,11 @@ options_asterisk_methods(Config) ->
                    [{"Host", "127.0.0.1:"++integer_to_list(Port2)}]
                   )),
     {ok, {{_,400,_}, Hdrs2, _}} = testsuite:receive_http_response(Sock2),
+    ?assert(not proplists:is_defined("allow", Hdrs2)),
+    ?assert(proplists:is_defined("server", Hdrs2)),
+    ?assert(proplists:is_defined("date", Hdrs2)),
     ?assertEqual(ok, gen_tcp:close(Sock2)),
+
     ok.
 
 http_head(Config) ->


### PR DESCRIPTION
* Remove unused yaws.conf options_asterisk_methods parse clause.

* Assert no allow header and assert server and date headers in
  400 response for OPTIONS *.