### PR TITLE
yaws.hrl: fix default IP in sconf

### DIFF
--- a/include/yaws.hrl
+++ b/include/yaws.hrl
@@ -227,7 +227,7 @@
           rmethod,                      % forced redirect method
           docroot,                      % path to the docs
           xtra_docroots = [],           % if we have additional pseudo docroots
-          listen = [{127,0,0,1}],       % bind to this IP, {0,0,0,0} is possible
+          listen = {127,0,0,1},         % bind to this IP, {0,0,0,0} is possible
           servername = "localhost",     % servername is what Host: header is
           serveralias = [],             % Alternate names for this vhost
           yaws,                         % server string for this vhost


### PR DESCRIPTION
Current default causes crash in gserv. Reproducible with this code:

    yaws_config:add_sconf(#sconf{port = 8888,
            docroot = "/home/max-au/wwwroot"
    }),