### PR TITLE
recommend SSL logging over built-in

### DIFF
--- a/src/yaws.erl
+++ b/src/yaws.erl
@@ -2689,6 +2689,8 @@ http_recv_request(CliSock, SSL) ->
             closed;
         {error, etimedout} ->
             closed;
+        {error, {tls_alert, _}} ->
+            closed;
         Other ->
             error_logger:format("Unhandled reply from yaws:do_recv(): ~p~n", [Other]),
             exit(normal)

--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -1052,16 +1052,10 @@ acceptor0(GS, Top) ->
                                   {error, closed} ->
                                       Top ! {self(), decrement},
                                       exit(normal);
-                                  {error, esslaccept} ->
-                                      %% Don't log SSL esslaccept to error log since it
-                                      %% seems this is what we get on portscans and
-                                      %% similar
-                                      ?Debug("SSL accept failed: ~p~n", [esslaccept]),
-                                      Top ! {self(), decrement},
-                                      exit(normal);
                                   {error, Reason} ->
-                                      error_logger:format("SSL accept failed: ~p~n",
-                                                          [Reason]),
+                                      %% Since OTP21, TLS alerts are logged by
+                                      %% SSL application itself, when enabled
+                                      ?Debug("SSL accept failed: ~p~n", [Reason]),
                                       Top ! {self(), decrement},
                                       exit(normal)
                               end;


### PR DESCRIPTION
OTP logger was introduced with OTP 21, and error_logger
is considered deprecated. Reducing usage of error_logger
in favour of SSL logging.