### PR TITLE
yaws: do not consider http_error to be a header

### DIFF
--- a/src/yaws.erl
+++ b/src/yaws.erl
@@ -2822,7 +2822,7 @@ http_collect_headers(CliSock, Req, H, SSL, Count) when Count < 1000 ->
             http_collect_headers(CliSock, Req, H,SSL, Count+1);
 
         %% auxiliary headers we don't have builtin support for
-        {ok, X} ->
+        {ok, {http_header, _Code, _Field, _UnmodifiedField, _Value} = X} ->
             ?Debug("OTHER header ~p~n", [X]),
             http_collect_headers(CliSock, Req,
                                  H#headers{other=[X|H#headers.other]},


### PR DESCRIPTION
It's possible that decode_packet returns {http_error, Reason}, which
will be added as "other headers", causing various unexpected crashes,
because later down the stream yaws expect 5-tuple of {http_header, ...}