### PR TITLE
Add support for setting the SameSite cookie option

### DIFF
--- a/man/yaws_api.5
+++ b/man/yaws_api.5
@@ -156,6 +156,7 @@ Sets a cookie to the browser. Options are:
                       which this cookie applies.
 {domain, Domain}    - Domain is a string that specifies the domain for which
                       the cookie is valid.
+{same_site, Policy} - Policy is one of the atoms lax, none or strict.
 {comment, Comment}  - Comment is a string that doccuments the server's
                       intended use of the cookie.
 secure              - Directs the user agent to use only secure means to

--- a/src/yaws_api.erl
+++ b/src/yaws_api.erl
@@ -715,6 +715,9 @@ cookie_option(expires, UTC) when is_tuple(UTC) ->
 cookie_option(max_age, Age) when is_integer(Age) ->
     V = if Age < 0 -> "0"; true -> integer_to_list(Age) end,
     ["; Max-Age=" | V];
+cookie_option(same_site, lax) -> ["; SameSite=Lax"];
+cookie_option(same_site, none) -> ["; SameSite=None"];
+cookie_option(same_site, strict) -> ["; SameSite=Strict"];
 cookie_option(path, Path) when is_list(Path), Path =/= [] ->
     ["; Path=" | Path];
 cookie_option(domain, Domain) when is_list(Domain), Domain =/= [] ->


### PR DESCRIPTION
Supported values are 'lax', 'none' and 'strict'.

Example:
  yaws_api:set_cookie("s", Cookie, [http_only, {same_site, strict}, ...]).

Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite

Closes #321