### PR TITLE
Detect externally rotated logfiles

### DIFF
--- a/src/yaws_log.erl
+++ b/src/yaws_log.erl
@@ -97,38 +97,44 @@ open_log(ServerName, Type, Dir) ->
                        ServerName
                end,
     A = filename:join([Dir, FileName ++ "." ++ atom_to_list(Type)]),
-    case file:open(A, [write, raw, append]) of
+    case open_logfile(A) of
         {ok, Fd} ->
-            {true, {Fd, A}};
+            {true, {Fd, A, safe_filesize(A)}};
         _Err ->
             error_logger:format("Cannot open ~p",[A]),
             false
     end.
 
-close_log(_ServerName, _Type, {Fd, _FileName}) ->
+close_log(_ServerName, _Type, {Fd, _FileName, _LastSize}) ->
     file:close(Fd).
 
-wrap_log(_ServerName, _Type, {Fd, FileName}, LogWrapSize) ->
-    case wrap_p(FileName, LogWrapSize) of
-        true ->
+wrap_log(_ServerName, _Type, {Fd, FileName, LastSize}, LogWrapSize) ->
+    case wrap_p(FileName, LastSize, LogWrapSize) of
+        need_wrap ->
             file:close(Fd),
             Old = [FileName, ".old"],
             file:delete(Old),
             file:rename(FileName, Old),
-            {ok, Fd2} = file:open(FileName, [write, raw]),
-            {Fd2, FileName};
+            {ok, Fd2} = open_logfile(FileName),
+            {Fd2, FileName, 0};
+        has_wrapped ->
+            error_logger:format("Logfile ~p externally wrapped - we reopen it",
+                                [FileName]),
+            file:close(Fd),
+            {ok, Fd2} = open_logfile(FileName),
+            {Fd2, FileName, safe_filesize(FileName)};
         false ->
-            {Fd, FileName};
+            {Fd, FileName, safe_filesize(FileName)};
         enoent ->
             %% Logfile disappeared,
             error_logger:format("Logfile ~p disappeared - we reopen it",
                                 [FileName]),
             file:close(Fd),
-            {ok, Fd2} = file:open(FileName, [write, raw]),
-            {Fd2, FileName}
+            {ok, Fd2} = open_logfile(FileName),
+            {Fd2, FileName, 0}
     end.
 
-write_log(ServerName, Type, {Fd, _FileName}, Infos) ->
+write_log(ServerName, Type, {Fd, _FileName, _LastSize}, Infos) ->
     gen_server:cast(yaws_log, {ServerName, Type, Fd, Infos}).
 
 %%%----------------------------------------------------------------------
@@ -374,21 +380,6 @@ handle_info({'EXIT', _, _}, State) ->
     {noreply, State}.
 
 
-
-wrap_p(Filename, LogWrapSize) ->
-    case file:read_file_info(Filename) of
-        {ok, FI} when FI#file_info.size > LogWrapSize, LogWrapSize > 0 ->
-            true;
-        {ok, _FI} ->
-            false;
-        {error, enoent} ->
-            enoent;
-        _ ->
-            false
-    end.
-
-
-
 %%----------------------------------------------------------------------
 %% Func: terminate/2
 %% Purpose: Shutdown the server
@@ -411,6 +402,29 @@ code_change(_OldVsn, Data, _Extra) ->
 %%%----------------------------------------------------------------------
 %%% Internal functions
 %%%----------------------------------------------------------------------
+wrap_p(Filename, LastSize, LogWrapSize) ->
+    case file:read_file_info(Filename) of
+        {ok, FI} when FI#file_info.size > LogWrapSize, LogWrapSize > 0 ->
+            need_wrap;
+        {ok, FI} when FI#file_info.size < LastSize ->
+            has_wrapped;
+        {ok, _FI} ->
+            false;
+        {error, enoent} ->
+            enoent;
+        _ ->
+            false
+    end.
+
+open_logfile(Filename) -> file:open(Filename, [append, raw]).
+
+safe_filesize(Filename) ->
+    case file:read_file_info(Filename) of
+        {ok, FI} -> FI#file_info.size;
+        _ -> 0
+    end.
+
+
 optional_header(Item) ->
     case Item of
         undefined -> "-";


### PR DESCRIPTION
Currently, Yaws does not play well with an external log rotation
mechanism (Linux logrotate or BSD newsyslog). When such an external
program rotates a Yaws log, it will customarily move the existing log
to a new name, open a new logfile with the old name, and (optionally)
send a (configurable) signal to the program that writes to the log, to
notify it to re-open the logfile.

Yaws supports wrapping its logs at a given size (configuration
variable log_wrap_size), but it does not support wrapping it in a
time-based fashion (e.g., wrap once a day at midnight), which is why
an external log rotator is useful.

The problem is that in such a case, Yaws will continue writing to the
old logfile. There is logic to detect that the logfile has been
wrapped, but it does not work if the log rotator creates a new file
in place of the old. In such case, Yaws should detect that the logfile
it sees at the expected path is smaller than what it knows to have
written to the log, and take that as a signal that the log has been
wrapped.

This patch adds support for just this. To make use of it, one should
arrange for the log rotator to issue a 'yaws --hup' post rotating the
files. This will trigger Yaws to immediately re-evaluate the
conditions and lead to migrating to the newly opened logfile.
Otherwise, it will take up to 10 minutes for this to happen, and Yaws
will have been writing to the old file (via the file descriptor it is
holding to) prior to that.