### PR TITLE
Update rebar3 branch to be ready for OTP 27

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Prepare build
 
 Get and install an Erlang system (http://www.erlang.org).
 
-**To compile Yaws, Erlang/OTP 18.0 or higher is required.**
+**To compile Yaws, Erlang/OTP 21.0 or higher is required.**
 
 If you've cloned the source from github and you want to build using autotools,
 note there is no ./configure script in the source, so create one:

--- a/doc/yaws.tex
+++ b/doc/yaws.tex
@@ -3453,9 +3453,22 @@ The following directives are allowed inside a server definition.
                  encrypted on disk, this password is the 3des key to decrypt it.
 
                \item \verb+ciphers = String+ --- This string specifies the SSL
-                 cipher string.  The syntax of the SSL cipher string is a little
-                 horrible sub-language of its own.  It is documented in the SSL
-                 man page for "ciphers".
+                 cipher string. The syntax of the SSL cipher string is
+                 a 4-tuple representation of the map returned by
+                 \verb+ssl:cipher_suites/2,3+:
+                 \verb+{#{key_exchange}, #{cipher}, #{mac}, #{prf}}+.
+\begin{verbatim}
+ciphers = "[{dhe_rsa,aes_256_cbc,sha,default_prf},
+            {dhe_dss,aes_256_cbc,sha,default_prf}]"
+\end{verbatim}
+                 In older versions of Yaws, a cipher tuple lacked the
+                 \verb+#{prf}+ element. When Yaws reads a cipher of
+                 the old format from configuration, it attempts to
+                 convert it to a 4-tuple by adding \verb+default_prf+
+                 for the \verb+#{prf}+ element. Be aware that this may
+                 not work for all ciphers; if it fails, manual
+                 intervention is needed to properly configure the
+                 ciphers in the new format.
 
                \item \verb+eccs = String+ --- This string specifies the
                  supported Elliptic Curve Cryptography (ECC).

--- a/man/yaws.conf.5
+++ b/man/yaws.conf.5
@@ -1173,13 +1173,21 @@ If the private key is encrypted on disc, this password is the
 .IP
 \fBciphers = String\fR
 .RS 12
-This string specifies the SSL cipher string. The syntax of the SSL cipher string
-is  an erlang term compliant with the output of ssl:cipher_suites().
+This string specifies the SSL cipher string. The syntax of the SSL
+cipher string is a 4-tuple representation of the map returned by
+ssl:cipher_suites/2,3: \fI{#{key_exchange}, #{cipher}, #{mac}, #{prf}}\fR.
 .nf
 
-ciphers = "[{dhe_rsa,aes_256_cbc,sha}, \\
-            {dhe_dss,aes_256_cbc,sha}]"
+ciphers = "[{dhe_rsa,aes_256_cbc,sha,default_prf}, \\
+            {dhe_dss,aes_256_cbc,sha,default_prf}]"
 .fi
+
+In older versions of Yaws, a cipher tuple lacked the \fI#{prf}\fR
+element. When Yaws reads a cipher of the old format from
+configuration, it attempts to convert it to a 4-tuple by adding
+\fIdefault_prf\fR for the \fI#{prf}\fR element. Be aware that this may
+not work for all ciphers; if it fails, manual intervention is needed
+to properly configure the ciphers in the new format.
 .RE
 
 .IP

--- a/src/yaws_zlib.erl
+++ b/src/yaws_zlib.erl
@@ -24,35 +24,35 @@ gzipEnd(Z) ->
 
 
 gzipDeflate(Z, undefined, Bin, Flush) ->
-    Crc32 = zlib:crc32(Z),
+    Crc32 = 0,
     Head = <<
-                                                % ID
+             %% ID
              16#1f, 16#8b,
-                                                % deflate
+             %% deflate
              8:8,
-                                                % flags
+             %% flags
              0:8,
-                                                % mtime
+             %% mtime
              0:32,
-                                                % xflags
+             %% xflags
              0:8,
-                                                % OS_UNKNOWN
-                                                % Set to Unix instead?
+             %% OS_UNKNOWN
+             %% Set to Unix instead?
              255:8>>,
     {ok, Priv, Bs} = gzipDeflate(Z, {Crc32,0}, Bin, Flush),
     {ok, Priv, [Head | Bs]};
 
 gzipDeflate(Z, {Crc32,Size}, Bin, Flush) ->
     Bs = zlib:deflate(Z, Bin, Flush),
-    Crc1 = zlib:crc32(Z, Crc32, Bin),
+    Crc1 = erlang:crc32(Crc32, Bin),
     Size1 = Size+size(Bin),
     Data =
         if
             Flush == finish ->
-                                                % Appending should not
-                                                % hurt, so let's be a
-                                                % bit more consistent
-                                                % here.
+                %% Appending should not
+                %% hurt, so let's be a
+                %% bit more consistent
+                %% here.
                 Bs ++ [<<Crc1:32/little, Size1:32/little>>];
             true ->
                 Bs

--- a/test/dhfile_SUITE.erl
+++ b/test/dhfile_SUITE.erl
@@ -50,7 +50,8 @@ ssl_with_valid_dhfile(Config) ->
     %% The server has its own Diffie-Hellman group. Try connecting with
     %% ephemeral DH and see if it works.
     SslOpts = [{versions, ['tlsv1.2']}|
-               [{ciphers, [C || {dhe_rsa, _, _}=C <- ssl:cipher_suites()]}]],
+               [{ciphers,[C || #{key_exchange := dhe_rsa}=C
+                                <- ssl:cipher_suites(all, 'tlsv1.2')]}]],
 
     ?assertMatch({ok, {{_,200,_}, _, _}}, testsuite:http_get(Url, [], [], SslOpts)),
     ok.
@@ -63,7 +64,8 @@ ssl_with_invalid_dhfile(Config) ->
     %% fails on ssl:ssl_accept/2. This sounds like a bug in ssl:listen/2 but
     %% that's how it works anyway.
     SslOpts = [{versions, ['tlsv1.2']}|
-               [{ciphers, [C || {dhe_rsa, _, _}=C <- ssl:cipher_suites()]}]],
+               [{ciphers, [C || #{key_exchange := dhe_rsa}=C
+                                 <- ssl:cipher_suites(all, 'tlsv1.2')]}]],
 
     ?assertMatch({error, _}, testsuite:http_get(Url, [], [], SslOpts)),
     ok.


### PR DESCRIPTION
Preparing to run OTP 27 has following warnings/errors on current rebar3-support branch:
```
Warning: zlib:crc32/1 is deprecated and will be removed in OTP 27; use erlang:crc32/1 on the uncompressed data instead
Warning: zlib:crc32/3 is deprecated and will be removed in OTP 27; use erlang:crc32/2 instead

Warning: ssl:cipher_suites/0 is removed; use cipher_suites/2,3 instead
```

This PR just applies existing diffs on master to rebar3-suppoort