### PR TITLE
Add case clause for '*' target in reformat_request/1

### DIFF
--- a/src/yaws_api.erl
+++ b/src/yaws_api.erl
@@ -1633,7 +1633,9 @@ reformat_request(Req) ->
                {abs_path, AbsPath} ->
                    AbsPath;
                {absoluteURI, _Scheme, _Host0, _Port, RawPath} ->
-                   RawPath
+                   RawPath;
+               '*' ->
+                   "*"
            end,
     {Maj, Min} = Req#http_request.version,
     [yaws:to_list(Req#http_request.method), " ", Path," HTTP/",


### PR DESCRIPTION
This commit adds a case clause in yaws_api:reformat_request/1 to handle
the * request target.

If e.g. an OPTIONS * request is sent when trace is enabled, the call
chain ends up in yaws_api:reformat_request/1 which crashes with case
clause. This is because '*' is the path and this case is not handled.