### PR TITLE
Document reproducible builds of YAWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,29 @@ Main make targets:
 * fullclean     : clean + cleantest + cleanapps + cleaninstaller
 
 
+Reproducible builds
+-------------------
+
+It is possible to build deterministically, thus enabling reproducible builds
+of YAWS.
+
+A determenistic build is enabled by setting the following environment
+variables when building
+
+    $> export YAWS_DETERMINISTIC_BUILD=true # set to any value will enable
+    $> export SOURCE_DATE_EPOCH=$known_unix_timestamp
+    $> make all doc
+
+The above environment variables will generate a deterministic
+`yaws_generated.beam` and sets e.g. creation date in `yaws.ps` and
+`yaws.pdf` from the value of `$SOURCE_DATE_EPOCH`.
+
+Note that various paths in configuration files, templates, examples etc, are
+generated from the configured installation prefix config files; thus they
+will vary if the installation prefix is different across builds. This can be
+mitigated by using DESTDIR when installing, see the Build section above.
+
+
 Test your build
 ---------------
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -44,8 +44,10 @@ install-data-local: doc
 
 endif
 
+# If set SOURCE_DATE_EPOCH replaces DVIPSSource date, for reproducible builds.
 yaws.ps: yaws.dvi
 	$(AM_V_GEN)TEXINPUTS="$${TEXTINPUTS}:@srcdir@" $(DVIPS) -q -o $@ $<
+	$(AM_V_at) [ x"$(SOURCE_DATE_EPOCH)" != "x" ] && sed -i "s/^\(%DVIPSSource:\s*TeX output\).*/\1 $$(date --date=@$$SOURCE_DATE_EPOCH +%Y%m%d:%H%M)/g" $@ || true
 
 yaws.pdf: yaws.tex $(IMG_PDF)
 	$(AM_V_GEN)TEXINPUTS="$${TEXTINPUTS}:@srcdir@" $(PDFLATEX) yaws.tex > /dev/null


### PR DESCRIPTION
Document how to enable reproducible builds (export environment variables
YAWS_DETERMINISTIC_BUILD and SOURCE_DATE_EPOCH when building) and what
that entails for the build artefacts. Also note that various paths are
included in generated files i.e. installation prefix affects build
artefacts, which can be mitigated by using DESTDIR.

SOURCE_DATE_EPOCH is understood by pdflatex, thus setting it to the same
unix timestamp across builds will make yaws.pdf build determenistically.
However, latex/dvips does not understand SOURCE_DATE_EPOCH, thus the
generated date in the DVIPSSource comment is generated from
SOURCE_DATE_EPOCH if set.

Fixes #446