### PR TITLE
Create a deterministic build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,20 +114,33 @@ Reproducible builds
 -------------------
 
 It is possible to build deterministically, thus enabling reproducible builds
-of YAWS.
+of Yaws.
 
-A deterministic build is enabled by setting the following environment
-variables when building:
+A deterministic build is enabled either by running `configure` with options
+`--enable-deterministic-build` and `--with-source-date-epoch`
+
+    $> ./configure --enable-deterministic-build \
+                   --with-source-date-epoch=$known_unix_timestamp
+
+or by setting the environment variables `YAWS_DETERMINISTIC_BUILD` and
+`SOURCE_DATE_EPOCH` before running `autoreconf` and `configure`,
+respectively
 
     $> export YAWS_DETERMINISTIC_BUILD=true # set to any value will enable
+    %> autoreconf -fi
     $> export SOURCE_DATE_EPOCH=$known_unix_timestamp
+    $> ./configure
+
+After any of the two above configurations are done, build like normal
+
     $> make all doc
 
-The above environment variables will generate a deterministic
-`yaws_generated.beam` and sets e.g. creation date in `yaws.ps` and
-`yaws.pdf` from the value of `$SOURCE_DATE_EPOCH`, which is expected to be
-an integer reflecting a number of seconds since the Unix epoch. (One way to
-get an epoch integer value is via the command `date '+%s'` on Linux or macOS,
+The above configurations that enables deterministic builds will add the erlc
+flag `+deterministic` (and remove `+debug_info`), generate a deterministic
+`yaws_generated.beam`, and set e.g. creation date in `yaws.ps` and
+`yaws.pdf` from the value of `SOURCE_DATE_EPOCH`, which is expected to be an
+integer reflecting a number of seconds since the Unix epoch. (One way to get
+an epoch integer value is via the command `date '+%s'` on Linux or macOS,
 for example.)
 
 Note that various paths in configuration files, templates, examples etc. are
@@ -135,6 +148,8 @@ generated from the configured installation prefix config files; thus they
 will vary if the installation prefix is different across builds. This can be
 mitigated by using DESTDIR when installing (see the Build section above for
 more details).
+
+In order to run all tests correctly, deterministic build have to be disabled.
 
 
 Test your build

--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,40 @@ if test "x$enable_compiler" = "xyes"; then
 fi
 AC_SUBST(APPDEPS)
 
+DEBUGINFO_OR_DETERMINISTIC=
+if test "x${YAWS_DETERMINISTIC_BUILD}" = "x"; then
+    DEBUGINFO_OR_DETERMINISTIC=+debug_info
+else
+    DEBUGINFO_OR_DETERMINISTIC=+deterministic
+    DETERMINISTIC_MACRO=-DDETERMINISTIC
+fi
+AC_ARG_ENABLE(deterministic_build,
+        AS_HELP_STRING([--enable-deterministic-build],
+                [enables deterministic Yaws build]))
+if test "x${enable_deterministic_build}" = "xyes"; then
+    DEBUGINFO_OR_DETERMINISTIC=+deterministic
+    DETERMINISTIC_MACRO=-DDETERMINISTIC
+    YAWS_DETERMINISTIC_BUILD=true
+fi
+AC_SUBST(YAWS_DETERMINISTIC_BUILD)
+AC_SUBST(DETERMINISTIC_MACRO)
+AC_SUBST(DEBUGINFO_OR_DETERMINISTIC)
+
+if test "x${SOURCE_DATE_EPOCH}" = "x"; then
+    SOURCE_DATE_EPOCH=
+else
+    SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
+fi
+AC_ARG_WITH(source_date_epoch,
+        AS_HELP_STRING([--with-source-date-epoch=EPOCH],
+                [sets build timestamp to `EPOCH`]),
+        with_source_date_epoch=${withval%/},
+        with_source_date_epoch="")
+if test "x${with_source_date_epoch}" != "x"; then
+    SOURCE_DATE_EPOCH=${with_source_date_epoch}
+fi
+AC_SUBST(SOURCE_DATE_EPOCH)
+
 
 dnl ------------------------------------------------------------------
 dnl Erlang environment.
@@ -434,7 +468,8 @@ dnl ------------------------------------------------------------------
 AC_SUBST([CONFIG_STATUS_DEPENDENCIES],
     ['$(top_srcdir)/vsn.mk                              \
       $(top_srcdir)/erlang_deps.mk                      \
-      $(top_srcdir)/include.mk                          \
+      $(top_srcdir)/include.mk.in                       \
+      $(top_srcdir)/scripts/gen-yaws-generated.in       \
       $(top_srcdir)/applications/yapp/vsn.mk            \
       $(top_srcdir)/testsuite/run_common_test.in        \
       $(top_srcdir)/testsuite/yaws.coverspec.in         \
@@ -445,6 +480,7 @@ AC_CONFIG_FILES([
         yaws.pc
 
         Makefile
+        include.mk
         c_src/Makefile
         win32/Makefile
         win32/build.xml
@@ -485,6 +521,7 @@ AC_CONFIG_FILES([testsuite/cover_to_html.sh],          [chmod +x testsuite/cover
 AC_CONFIG_FILES([testsuite/analyze_coverdata.escript], [chmod +x testsuite/analyze_coverdata.escript])
 
 AC_CONFIG_FILES([scripts/make-release],                  [chmod +x scripts/make-release])
+AC_CONFIG_FILES([scripts/gen-yaws-generated],            [chmod +x scripts/gen-yaws-generated])
 AC_CONFIG_FILES([applications/wiki/scripts/addFile],     [chmod +x applications/wiki/scripts/addFile])
 AC_CONFIG_FILES([applications/wiki/scripts/getPassword], [chmod +x applications/wiki/scripts/getPassword])
 AC_CONFIG_FILES([applications/wiki/scripts/importFiles], [chmod +x applications/wiki/scripts/importFiles])

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,5 +1,6 @@
 IMG_EPS = a.eps b.eps layout.eps yaws_head.eps
 IMG_PDF = $(IMG_EPS:.eps=.pdf)
+SOURCE_DATE_EPOCH = @SOURCE_DATE_EPOCH@
 
 EXTRA_DIST = $(IMG_EPS) overview.edoc README.rss yaws.tex
 
@@ -46,9 +47,11 @@ endif
 
 # For reproducible builds, SOURCE_DATE_EPOCH replaces DVIPSSource date if set
 yaws.ps: yaws.dvi
-	$(AM_V_GEN)TEXINPUTS="$${TEXTINPUTS}:@srcdir@" $(DVIPS) -q -o $@ $<
+	$(AM_V_GEN)TEXINPUTS="$${TEXTINPUTS}:@srcdir@" \
+		SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
+		$(DVIPS) -q -o $@ $<
 	$(AM_V_at)if [ x"$(SOURCE_DATE_EPOCH)" != "x" ]; then \
-	  code='{{Y,Mo,D},{H,Mi,S}} = calendar:system_time_to_local_time('$$SOURCE_DATE_EPOCH', 1),' ; \
+	  code='{{Y,Mo,D},{H,Mi,S}} = calendar:system_time_to_local_time('$(SOURCE_DATE_EPOCH)', 1),' ; \
 	  code="$$code "'io:format("~4.4w~2.2.0w~2.2.0w:~2.2.0w~2.2.0w~2.2.0w\n", [Y,Mo,D,H,Mi,S]).' ; \
 	  newdate=`$(ERL) -noshell -noinput -eval "$$code" -s init stop` || exit 1; \
 	  mv -f $@ $(@).tmp || exit 1 ; \
@@ -59,15 +62,24 @@ yaws.ps: yaws.dvi
 	fi
 
 yaws.pdf: yaws.tex $(IMG_PDF)
-	$(AM_V_GEN)TEXINPUTS="$${TEXTINPUTS}:@srcdir@" $(PDFLATEX) yaws.tex > /dev/null
-	$(AM_V_at)TEXINPUTS="$${TEXTINPUTS}:@srcdir@"  $(PDFLATEX) yaws.tex > /dev/null
+	$(AM_V_GEN)TEXINPUTS="$${TEXTINPUTS}:@srcdir@" \
+		SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
+		$(PDFLATEX) yaws.tex > /dev/null
+	$(AM_V_at)TEXINPUTS="$${TEXTINPUTS}:@srcdir@" \
+		SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)  \
+		$(PDFLATEX) yaws.tex > /dev/null
 
 yaws.dvi: yaws.tex $(IMG_EPS)
-	$(AM_V_GEN)TEXINPUTS="$${TEXTINPUTS}:@srcdir@" $(DVILATEX) yaws.tex > /dev/null
-	$(AM_V_at)TEXINPUTS="$${TEXTINPUTS}:@srcdir@"  $(DVILATEX) yaws.tex > /dev/null
+	$(AM_V_GEN)TEXINPUTS="$${TEXTINPUTS}:@srcdir@" \
+		SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
+		$(DVILATEX) yaws.tex > /dev/null
+	$(AM_V_at)TEXINPUTS="$${TEXTINPUTS}:@srcdir@" \
+		SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
+		$(DVILATEX) yaws.tex > /dev/null
 
 .eps.pdf:
-	$(AM_V_GEN)$(EPSTOPDF) --outfile=$@ $< > /dev/null
+	$(AM_V_GEN)SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
+		$(EPSTOPDF) --outfile=$@ $< > /dev/null
 
 .NOTPARALLEL:
 # Local Variables:

--- a/include.mk.in
+++ b/include.mk.in
@@ -8,7 +8,13 @@ am__v_ERLC_1 =
 #WARNINGS_AS_ERRORS = -Werror
 WARNINGS_AS_ERRORS =
 
-ERLC_GENERIC_FLAGS = $(WARNINGS_AS_ERRORS) +debug_info $(DEBUG_ERLC_FLAGS)		\
+DEBUGINFO_OR_DETERMINISTIC = @DEBUGINFO_OR_DETERMINISTIC@
+DETERMINISTIC_MACRO = @DETERMINISTIC_MACRO@
+SOURCE_DATE_EPOCH ?= @SOURCE_DATE_EPOCH@
+
+ERLC_GENERIC_FLAGS = $(WARNINGS_AS_ERRORS) \
+		     $(DEBUGINFO_OR_DETERMINISTIC) $(DEBUG_ERLC_FLAGS)		\
+		     $(DETERMINISTIC_MACRO) \
 		     -pa $(top_srcdir) -pa $(top_builddir) -pa $(top_builddir)/ebin	\
 		     -I $(top_srcdir)/include -I $(srcdir)/../include 			\
 		     -I $(top_builddir)/include -I $(builddir)/../include

--- a/scripts/gen-yaws-generated.in
+++ b/scripts/gen-yaws-generated.in
@@ -5,7 +5,7 @@
 
 set -e
 
-if [ x"$YAWS_DETERMINISTIC_BUILD" = x ]; then
+if [ x"@YAWS_DETERMINISTIC_BUILD@" = x ]; then
     subst_vardir="${VARDIR}"
     subst_etcdir="${ETCDIR}"
 else

--- a/scripts/rebar-pre-script
+++ b/scripts/rebar-pre-script
@@ -55,9 +55,10 @@ fi
 
 ## generate yaws_generated.erl module
 ## For deterministic builds, which avoids embedding differing
-## pathnames in the yaws_generated beam file, set
-## YAWS_DETERMINISTIC_BUILD as an environment variable (any value will
-## do, the value is not used).
+## pathnames in the yaws_generated beam file,
+## ./configure --enable-deterministic-bulid or set YAWS_DETERMINISTIC_BUILD as
+## an environment variable (any value will do, the value is not used) before
+## running ./configure.
 cd ${YAWS_DIR}/src || fail
 tmpgen=`mktemp /tmp/${SCRIPT}.XXXXXX` || fail
 YAWS_VSN="${YAWS_VSN}" VARDIR="${YAWS_VARDIR}" ETCDIR="${YAWS_ETCDIR}"  \

--- a/src/mime_type_c.erl
+++ b/src/mime_type_c.erl
@@ -37,6 +37,19 @@ generate() ->
     end.
 
 
+%% Deterministic Yaws builds use hardcoded path. For tests to work the absolute
+%% generated path to the yaws source directory is needed.
+-ifdef(DETERMINISTIC).
+include_yaws_hrl() ->
+    "-include(\"../include/yaws.hrl\").".
+-else.
+include_yaws_hrl() ->
+    IncDir  = yaws:get_inc_dir(),
+    IncFile = filename:join(IncDir, "yaws.hrl"),
+    "-include(\""++IncFile++"\").".
+-endif.
+
+
 %% GInfo      ::= #mime_types_info{}
 %% SInfoMap   ::= [{{ServerName, Port}, #mime_types_info{}}]
 %% ServerName ::= string() | atom()
@@ -47,15 +60,12 @@ generate(ModFile, GInfo, SInfoMap) ->
                             {Name, Info} <- [{global, GInfo}|SInfoMap] ],
 
             %% Generate module Header
-            IncDir  = yaws:get_inc_dir(),
-            IncFile = filename:join(IncDir, "yaws.hrl"),
-            Include = "-include(\""++IncFile++"\").",
             io:format(Fd,
                       "-module(mime_types).~n~n"
                       "-export([default_type/0, default_type/1]).~n"
                       "-export([t/1, revt/1]).~n"
                       "-export([t/2, revt/2]).~n~n"
-                      "~s~n~n", [Include]),
+                      "~s~n~n", [include_yaws_hrl()]),
 
 
             %% Generate default_type/0, t/1 and revt/1

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -17,7 +17,8 @@ EBIN_FILES=$(MODULES:%.erl=$(EBIN_DIR)/%.beam)
 
 LOG_DIR=@builddir@/logs
 
-ERLC_FLAGS = $(ERLC_GENERIC_FLAGS) -DSHOW_LOG +nowarn_export_all
+ERLC_FLAGS = $(filter-out +deterministic,$(ERLC_GENERIC_FLAGS)) \
+			 -DSHOW_LOG +nowarn_export_all
 
 include @top_srcdir@/erlang_deps.mk
 

--- a/www/code/Makefile.am
+++ b/www/code/Makefile.am
@@ -1,5 +1,28 @@
 include @top_srcdir@/include.mk
 
+# For reproducible builds. Neither of these are used.
+# This is a little bit hacky, but no one should need these to
+# use the examples.
+
+# Don't use build environments SHELL
+SHELL = /bin/sh
+
+# Omit build environment paths
+abs_builddir =
+abs_srcdir =
+abs_top_builddir =
+abs_top_srcdir =
+
+# Remove ac-aux/missing helper script from commands, contains absolute path.
+ACLOCAL = aclocal
+AUTOCONF = autoconf
+AUTOHEADER = autoheader
+AUTOMAKE = automake
+MAKEINFO = makeinfo
+
+# Remove ac-aux/install_sh helper script, contains absolute path.
+install_sh =
+
 MODULES = myappmod.erl
 
 EXTRA_DIST = $(MODULES)

--- a/www/shoppingcart/Makefile.am
+++ b/www/shoppingcart/Makefile.am
@@ -1,5 +1,28 @@
 include @top_srcdir@/include.mk
 
+# For reproducible builds. Neither of these are used.
+# This is a little bit hacky, but no one should need these to
+# use the examples.
+
+# Don't use build environments SHELL
+SHELL = /bin/sh
+
+# Omit build environment paths
+abs_builddir =
+abs_srcdir =
+abs_top_builddir =
+abs_top_srcdir =
+
+# Remove ac-aux/missing helper script from commands, contains absolute path.
+ACLOCAL = aclocal
+AUTOCONF = autoconf
+AUTOHEADER = autoheader
+AUTOMAKE = automake
+MAKEINFO = makeinfo
+
+# Remove ac-aux/install_sh helper script, contains absolute path.
+install_sh =
+
 MODULES = shopcart.erl
 
 EXTRA_DIST = $(MODULES)


### PR DESCRIPTION
This commit creates a deterministic build environment, which enables
reproducible builds.

* Hardcode include path in generated mime_types.erl

* If YAWS_DETERMINISTIC_BUILD is set, set the +deterministic compiler
  flag.

  Remove +deterministic when building tests

  The *_SUITE_data directories will not be handled correctly when
  +determenistic is used. When the beam files are built once, they will
  try to rebuild on the next make invocation and it will not work. I.e.
  if the beam is built, it will be built again. This breaks the pattern
  make && make install.

* Generate deterministic www/*/Makefile

  Several things are taken from the build environment when building,
  they are not needed to build or use the examples and are hence
  hardcoded or just removed.

  The SHELL variable in www/code/Makefile and www/shoppingcart/Makefile
  is taken from the build environment when generated. To enable
  reproducible builds hardcode SHELL = /bin/sh.

  Omit build environment paths.

  Remove calls to ac-aux/missing and ac-aux/install-sh, they include
  absolute build environment paths.

See #446