### PR TITLE
Drop stacktrace polyfill

### DIFF
--- a/include/yaws.hrl
+++ b/include/yaws.hrl
@@ -394,15 +394,7 @@
 
 %% Typically used in error printouts as in:
 %% error_logger:format("Err ~p at ~p~n", [Reason, ?stack()])
--ifdef(OTP_RELEASE).
 -define(stack(), try throw(1) catch _:_:ST -> ST end).
--define(MAKE_ST(CATCH,STVAR,BODY), CATCH:STVAR -> BODY).
--else.
--define(stack(), try throw(1) catch _:_ -> (fun erlang:get_stacktrace/0)() end).
--define(MAKE_ST(CATCH,STVAR,BODY),
-        CATCH -> STVAR = (fun erlang:get_stacktrace/0)(), BODY).
--endif.
-
 
 %%% The following is for emacs, do not remove
 %%% Local Variables:

--- a/src/jsonrpc.erl
+++ b/src/jsonrpc.erl
@@ -31,8 +31,6 @@
 -export([call/3]).
 -export([s/2]).        % extract element from proplist
 
--include("../include/yaws.hrl").
-
 %%%
 %%% call function calls json-rpc method on remote host
 %%%
@@ -60,13 +58,11 @@ call(URL, Options, Payload) ->
                    end,
         decode_call_payload(RespBody)
     catch
-        ?MAKE_ST(error:Err,St,
-                 begin
-                     error_logger:error_report([{'json_rpc:call', error},
-                                                {error, Err},
-                                                {stack, St}]),
-                     {error,Err}
-                 end)
+        error:Err:St ->
+            error_logger:error_report([{'json_rpc:call', error},
+                                       {error, Err},
+                                       {stack, St}]),
+            {error,Err}
     end.
 
 %%%

--- a/src/yaws_appmod_dav.erl
+++ b/src/yaws_appmod_dav.erl
@@ -81,13 +81,11 @@ out(A) ->
             error_logger:error_msg(Msg),
             Response = [{'D:error',[{'xmlns:D',"DAV:"}],[Msg]}],
             status(500,{xml,Response});
-        ?MAKE_ST(_Error:Reason,ST,
-                 begin
-                     error_logger:info_msg("unexpected error: ~p~n~p~n",
-                                           [Reason, ST]),
-                     Response = [{'D:error',[{'xmlns:D',"DAV:"}],[Reason]}],
-                     status(500,{xml,Response})
-                 end)
+        _Error:Reason:ST ->
+            error_logger:info_msg("unexpected error: ~p~n~p~n",
+                                  [Reason, ST]),
+            Response = [{'D:error',[{'xmlns:D',"DAV:"}],[Reason]}],
+            status(500,{xml,Response})
     end.
 
 %%------------------------------------------------------

--- a/src/yaws_runmod_lock.erl
+++ b/src/yaws_runmod_lock.erl
@@ -102,12 +102,10 @@ handle_call({lock,Path,Lock}, _From, Table) ->
         {reply, {ok,Id}, Table1}
     catch
         Status -> {reply, {error, Status}, Table};
-        ?MAKE_ST(_Error:Reason,ST,
-                 begin
-                     error_logger:error_msg("Unexpected error: ~p~n~p~n",
-                                            [Reason, ST]),
-                     {reply, {error, Reason}, Table}
-                 end)
+        _Error:Reason:ST ->
+            error_logger:error_msg("Unexpected error: ~p~n~p~n",
+                                   [Reason, ST]),
+            {reply, {error, Reason}, Table}
     end;
 handle_call({unlock,Path,Id}, _From, Table) ->
     % even if the lock is not found, its removal is succesfull


### PR DESCRIPTION
Yaws requires OTP 21.3 - the `Class:Reason:Stack` syntax was introduced in
OTP 21, thus the macro filling in for compatibility with older versions
is no longer needed and can be removed.