### PR TITLE
Make all erlang files UTF-8

### DIFF
--- a/src/yaws_exhtml.erl
+++ b/src/yaws_exhtml.erl
@@ -1,9 +1,8 @@
-%% -*- coding: latin-1 -*-
 %%%----------------------------------------------------------------------
 %%% File    : exhtml.erl
-%%% Author  : Joakim Grebenö <jocke@tail-f.com>
+%%% Author  : Joakim GrebenÃ¶ <jocke@tail-f.com>
 %%% Purpose : Format ehtml as xhtml code with optional indentation support.
-%%% Created : 24 Apr 2006 by Joakim Grebenö <jocke@tail-f.com>
+%%% Created : 24 Apr 2006 by Joakim GrebenÃ¶ <jocke@tail-f.com>
 %%%----------------------------------------------------------------------
 
 -module(yaws_exhtml).

--- a/src/yaws_jsonrpc.erl
+++ b/src/yaws_jsonrpc.erl
@@ -1,4 +1,3 @@
-%% -*- coding: latin-1 -*-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% WARNING DEPRECATED WARNING DEPRECATED WARNING DEPRECATED WARNING DEPRECATED
@@ -14,7 +13,7 @@
 %%% WARNING DEPRECATED WARNING DEPRECATED WARNING DEPRECATED WARNING DEPRECATED
 %%% WARNING DEPRECATED WARNING DEPRECATED WARNING DEPRECATED WARNING DEPRECATED
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% Copyright (C) 2003 Joakim Grebenö <jocke@gleipnir.com>.
+%% Copyright (C) 2003 Joakim GrebenÃ¶ <jocke@gleipnir.com>.
 %% All rights reserved.
 %%
 %% Copyright (C) 2006 Gaspar Chilingarov <nm@web.am>

--- a/src/yaws_ls.erl
+++ b/src/yaws_ls.erl
@@ -1,11 +1,10 @@
-%% -*- coding: latin-1 -*-
 %%%----------------------------------------------------------------------
 %%% File    : yaws_ls.erl
 %%% Author  : Claes Wikstrom <klacke@hyber.org>
 %%% Purpose :
 %%% Created :  5 Feb 2002 by Claes Wikstrom <klacke@hyber.org>
 %%% Modified: 13 Jan 2004 by Martin Bjorklund <mbj@bluetail.com>
-%%% Modified:    Jan 2006 by Sébastien Bigot <sebastien.bigot@tremplin-utc.net>
+%%% Modified:    Jan 2006 by SÃ©bastien Bigot <sebastien.bigot@tremplin-utc.net>
 %%%----------------------------------------------------------------------
 
 -module(yaws_ls).

--- a/src/yaws_rpc.erl
+++ b/src/yaws_rpc.erl
@@ -1,5 +1,4 @@
-%% -*- coding: latin-1 -*-
-%% Copyright (C) 2003 Joakim Grebenö <jocke@gleipnir.com>.
+%% Copyright (C) 2003 Joakim GrebenÃ¶ <jocke@gleipnir.com>.
 %% All rights reserved.
 %%
 %% Copyright (C) 2006 Gaspar Chilingarov <nm@web.am>

--- a/src/yaws_xmlrpc.erl
+++ b/src/yaws_xmlrpc.erl
@@ -1,5 +1,4 @@
-%% -*- coding: latin-1 -*-
-%% Copyright (C) 2003 Joakim Grebenö <jocke@gleipnir.com>.
+%% Copyright (C) 2003 Joakim GrebenÃ¶ <jocke@gleipnir.com>.
 %% All rights reserved.
 %%
 %% Copyright (C) 2006 Gaspar Chilingarov <nm@web.am>


### PR DESCRIPTION
All the Erlang versions that are currently supported by yaws,
default to UTF-8 files. This converts the couple comments that
were encoded in Latin-1 to UTF-8 and removes the coding comments.