### PR TITLE
Prevent CRLF injections in redirects

### DIFF
--- a/src/yaws_api.erl
+++ b/src/yaws_api.erl
@@ -888,10 +888,10 @@ url_decode_q_split(Path, {encoding, Encoding}) ->
 url_decode_q_split([$%, Hi, Lo | Tail], Ack) ->
     Hex = yaws:hex_to_integer([Hi, Lo]),
     if Hex == 0 -> exit(badurl);
+       Hex == $\r; Hex == $\n; %% prevent CRLF injection
        %% RFC 3986 section 2.2 says that encoded reserved characters
        %% should not be decoded, otherwise the meaning of the URL data
        %% changes
-       Hex == $\r; Hex == $\n; %% prevent CRLF injection
        Hex == $:; Hex == $/; Hex == $?; Hex == $#;
        Hex == $[; Hex == $]; Hex == $@;
        Hex == $!; Hex == $$; Hex == $&; Hex == $';

--- a/src/yaws_api.erl
+++ b/src/yaws_api.erl
@@ -891,6 +891,7 @@ url_decode_q_split([$%, Hi, Lo | Tail], Ack) ->
        %% RFC 3986 section 2.2 says that encoded reserved characters
        %% should not be decoded, otherwise the meaning of the URL data
        %% changes
+       Hex == $\r; Hex == $\n; %% prevent CRLF injection
        Hex == $:; Hex == $/; Hex == $?; Hex == $#;
        Hex == $[; Hex == $]; Hex == $@;
        Hex == $!; Hex == $$; Hex == $&; Hex == $';


### PR DESCRIPTION
Redirect mappings specified in configuration are subject to CRLF injections, meaning path to be redirected to on another domain is copied in the Location header, including unencoded \r and \n characters.
This could lead to unwanted headers to be added in the server reply, for example a Set-cookie directive.

Example in conf:
```
<server domain1>
 <redirect>
  / = 301 https://domain2
 </redirect>
</server>
```
Now, going to  https://domain1/%0D%0ASet-Cookie:crlfinjection=crlfinjection would generate this reply:
```
HTTP 1.1 301 Moved Permanently
Location: https://domain2/ 
Set-Cookie: crlfinjection=crlfinjection
...
```
This patch encode those \r\n characters as normal characters to prevent injection, whereas they were considered as reserved.