### PR TITLE
fgrep is deprecated, use grep -F instead

### DIFF
--- a/scripts/Subst
+++ b/scripts/Subst
@@ -3,7 +3,7 @@
 
 p=$1
 
-if [ `uname -a | fgrep -c Cygwin` != 0 ]; then
+if [ `uname -a | grep -F -c Cygwin` != 0 ]; then
     d=`cygpath -m "$2"`
 else
     d=$2


### PR DESCRIPTION
The `fgrep` command was deprecated in 2007 and with recent versions of GNU `grep` it'll now print:

```
fgrep: warning: fgrep is obsolescent; using grep -F
```

Just use the POSIX-compliant `grep -F` instead.
