### PR TITLE
Correct parsing of basic authentication to comply with RFC7617

### DIFF
--- a/src/yaws.erl
+++ b/src/yaws.erl
@@ -2948,12 +2948,9 @@ parse_auth(Orig = "Basic " ++ Auth64) ->
         {error, _Err} ->
             {undefined, undefined, Orig};
         Auth ->
-            case string:tokens(Auth, ":") of
-                [User, Pass ] ->
-                    {User, Pass, Orig};
-                [User, Pass0 | Extra] ->
-                    %% password can contain :
-                    Pass = join_sep([Pass0 | Extra], ":"),
+            case string:split(Auth, ":") of
+                %% Password can contain colons, username cannot (RFC7617).
+                [User, Pass] when User /= [] ->
                     {User, Pass, Orig};
                 _ ->
                     {undefined, undefined, Orig}

--- a/testsuite/auth_SUITE.erl
+++ b/testsuite/auth_SUITE.erl
@@ -53,7 +53,16 @@ end_per_testcase(_Test, _Config) ->
     ok.
 
 %%====================================================================
+check_auth_parsing(User, Password) ->
+    {_, Auth} = auth_header(User, Password),
+    ?assertMatch({User, Password, Auth}, yaws:parse_auth(Auth)).
+
 basic_auth(Config) ->
+    check_auth_parsing("foo", ""),
+    check_auth_parsing("foo", ":"),
+    check_auth_parsing("foo", "bar"),
+    check_auth_parsing("foo", "::bar:::frob::::"),
+
     Port  = testsuite:get_yaws_port(1, Config),
     Url   = testsuite:make_url(http, "127.0.0.1", Port, "/test1/a.txt"),
     Auth1 = auth_header("foo", "baz"),


### PR DESCRIPTION
According to RFC7617 the password consists of everything following the first colon, including any colons.

Using string:tokens/2 effectively removes any leading and or trailing colons, and compacts all multiple colons in the password into single ones: `Auth = "foo:::bar:::frob::::"` gives `{"foo", "bar:frob"}`, which obviously is incorrect. The PR changes this to returning `{"foo", "::bar:::frob::::"}`.