### PR TITLE
Fix test failing on OTP 27.0-rc1

### DIFF
--- a/www/index.yaws
+++ b/www/index.yaws
@@ -49,7 +49,8 @@ out(A) ->
                  "https://travis-ci.org/klacke/yaws"}]},
 
         {p,[], ["A mailing list exists at: ",
-                {a,[{href,"https://lists.sourceforge.net/lists/listinfo/""erlyaws-list"}],
+                {a,[{href,"https://lists.sourceforge.net/lists/listinfo/"
+                          "erlyaws-list"}],
                  "https://lists.sourceforge.net/lists/listinfo/erlyaws-list"}]},
          {p, [], ["A lot of excellent"
                  " engineers have contributed to Yaws over the years, "


### PR DESCRIPTION
The yaws_compile_SUITE:compile_www_scripts test fails on OTP 27.0-rc1.

Apparently whitespace is now needed for adjacent strings, e.g.:

    "my""string"

does not compile any longer since whitespace separation is needed, e.g.:

    "my" "string"

or with a newline:

    "my"
    "string"

Fixes #482