### PR TITLE
pass verify_none to httpc:request

### DIFF
--- a/src/yaws_soap12_lib.erl
+++ b/src/yaws_soap12_lib.erl
@@ -545,7 +545,8 @@ addSchemaFiles([Xsd| Tail], AccModel, Options, ImportList) ->
 %%% Get a file from an URL spec.
 %%% --------------------------------------------------------------------
 get_url_file("http://"++_ = URL) ->
-    case httpc:request(URL) of
+    HttpOptions = [{ssl, [{verify, verify_none}]}],
+    case httpc:request(get, {URL, []}, HttpOptions, []) of
         {ok,{{_HTTP,200,_OK}, _Headers, Body}} ->
             {ok, Body};
         {ok,{{_HTTP,RC,Emsg}, _Headers, _Body}} ->
@@ -596,11 +597,13 @@ inets_request(URL, Action, Request, Options, Headers, ContentType) ->
                  end,
     NewOptions = [{cookies, enabled}|Options],
     httpc:set_options(NewOptions),
+    HttpOptions = [{timeout,?HTTP_REQ_TIMEOUT},
+                   {ssl, [{verify, verify_none}]}],
     case httpc:request(post,
                        {URL,NewHeaders,
                         ContentType,
                         Request},
-                       [{timeout,?HTTP_REQ_TIMEOUT}],
+                       HttpOptions,
                        [{sync, true}, {full_result, true},
                         {body_format, string}]) of
         {ok,{{_HTTP,200,_OK},ResponseHeaders,ResponseBody}} ->

--- a/src/yaws_soap_lib.erl
+++ b/src/yaws_soap_lib.erl
@@ -409,7 +409,8 @@ get_url_file(Fname) ->
     {ok, binary_to_list(Bin)}.
 
 get_remote_url_file(URL) ->
-    case httpc:request(URL) of
+    HttpOptions = [{ssl, [{verify, verify_none}]}],
+    case httpc:request(get, {URL, []}, HttpOptions, []) of
         {ok,{{_HTTP,200,_OK}, _Headers, Body}} ->
             {ok, Body};
         {ok,{{_HTTP,RC,Emsg}, _Headers, _Body}} ->
@@ -447,11 +448,13 @@ inets_request(URL, SoapAction, Request, Options, Headers, ContentType) ->
                  end,
     NewOptions = [{cookies, enabled}|Options],
     httpc:set_options(NewOptions),
+    HttpOptions = [{timeout,?HTTP_REQ_TIMEOUT},
+                   {ssl, [{verify, verify_none}]}],
     case httpc:request(post,
                        {URL,NewHeaders,
                         ContentType,
                         Request},
-                       [{timeout,?HTTP_REQ_TIMEOUT}],
+                       HttpOptions,
                        [{sync, true}, {full_result, true},
                         {body_format, string}]) of
         {ok,{{_HTTP,200,_OK},ResponseHeaders,ResponseBody}} ->


### PR DESCRIPTION
The `ssl` changes in OTP-26 mean that any code that doesn't specify `verify_none` will _default_ to `verify_peer`, and unless certs are passed in you get hard errors. This also affects `httpc:request`. Update uses of the latter to explicitly pass in `verify_none`.