### PR TITLE
Generate erlyaws.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@ This is Yaws, a webserver for dynamic content written in Erlang.
 
 ![Build Status](https://github.com/erlyaws/yaws/actions/workflows/main.yml/badge.svg)
 
+Yaws Web Page
+-------------
+
+The
+[Yaws Web Page](https://erlyaws.github.io/) is available online with
+documentation and examples.
+
 Yaws Mailing List
 -----------------
 

--- a/scripts/update-gh-pages
+++ b/scripts/update-gh-pages
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+set -e
+
+[ -f LICENSE ] || { echo "Not in source tree root"; exit 1; }
+
+YAWS_ROOT="$PWD"
+BUILD_ROOT="$YAWS_ROOT/build"
+mkdir -p "$BUILD_ROOT"
+BUILD_DIR="$(mktemp -d "$BUILD_ROOT/gh-pages.XXXX")"
+INST_DIR="$BUILD_DIR/_inst"
+REPO=erlyaws.github.io
+YAWS_ID=update-gh-pages-yaws-server-$(date +%s)
+
+# FIXME cleanup when automating this
+# cleanup upon exit
+trap "pkill -f $YAWS_ID; rm -rf \"$BUILD_ROOT\"" 0 1 2 3 15
+
+# build and install yaws
+cd "$YAWS_ROOT"
+mkdir -p "$INST_DIR"
+autoreconf -fiv
+./configure --prefix="$INST_DIR"
+make all install
+
+# start yaws
+# FIXME --id doesn't seem to work
+"$INST_DIR"/bin/yaws --daemon #--id $YAWS_ID
+"$INST_DIR"/bin/yaws --wait-started #--id $YAWS_ID
+
+# clone erlyaws.github.io gh-pages repo
+cd "$BUILD_DIR"
+git clone git@github.com:erlyaws/$REPO
+
+# mirror the site
+wget --mirror \
+     --max-redirect 0 \
+     --directory-prefix $REPO \
+     --no-host-directories \
+     localhost:8000
+
+# FIXME stop yaws
+
+# push updates
+cd $REPO
+git add .
+git commit -av -m "Update gh-pages"
+git push origin main

--- a/www/TAB.inc
+++ b/www/TAB.inc
@@ -28,7 +28,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 <div class="%%index%%"> <a href="index.yaws" id="index" >Top Page</a> </div>
 <div class="%%configuration%%"> <a href="configuration.yaws" id="configuration">Build Config and Run</a></div>
 <div class="%%dynamic%%"> <a href="dynamic.yaws" id="dynamic" >Dynamic Content</a> </div>
-<div class="%%download%%"> <a href="http://yaws.hyber.org/download/" id="download">Download </a> </div>
+<div class="%%download%%"> <a href="http://github.com/erlyaws/yaws/releases/" id="download">Download </a> </div>
 <div class="%%contact%%"> <a href="contact.yaws" id="contact">Contact </a> </div>
 <div class="%%doc%%"> <a href="doc.yaws" id="doc">Documentation</a>  </div>
 <div class="%%articles%%"> <a href="articles.yaws" id="resources">Articles</a> </div>

--- a/www/index.yaws
+++ b/www/index.yaws
@@ -30,13 +30,13 @@ out(A) ->
          "well. Web applications don't have to be written in ugly ad hoc "
          "languages."},
 
-        {h2,[], "yaws.hyber.org"},
+        {h2,[], "erlyaws.github.io"},
 
         {p,[], ["The www page for Yaws is ",
-                {a ,[{href,"http://yaws.hyber.org"}], "yaws.hyber.org"},
+                {a ,[{href,"http://erlyaws.github.io"}], "erlyaws.github.io"},
                 ". The documentation, examples as well as releases can be "
                 "found there, and of course, ",
-                {a ,[{href,"http://yaws.hyber.org"}],"yaws.hyber.org"},
+                {a ,[{href,"http://erlyaws.github.io"}],"erlyaws.github.io"},
                 " is itself powered by Yaws."]},
 
 
@@ -45,8 +45,10 @@ out(A) ->
                   "http://github.com/erlyaws/yaws"}]},
 
         {p, [], ["Travis test results at :",
-                 {a, [{href, "https://travis-ci.org/klacke/yaws"}],
-                 "https://travis-ci.org/klacke/yaws"}]},
+                 {a, [{href, "https://github.com/erlyaws/yaws/actions"
+                             "/workflows/main.yml"}],
+                 "https://github.com/erlyaws/yaws/actions"
+                 "/workflows/main.yml"}]},
 
         {p,[], ["A mailing list exists at: ",
                 {a,[{href,"https://lists.sourceforge.net/lists/listinfo/"


### PR DESCRIPTION
This does a static mirror of the Yaws web page for publication as github pages on erlyaws.github.io.

Fixes #486