### PR TITLE
Stop stripping debug info outside of release

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -35,6 +35,7 @@
 {relx, [{release, {yaws, {git, short}},
          [yaws],
          {dev_mode, true},
+         {debug_info, strip},
          {include_erts, false},
          {extended_start_script, true}}]}.
 
@@ -43,8 +44,7 @@
                    },
                    {relx, [{dev_mode, true},
                            {include_erts, false}]}]},
-            {prod, [{erl_opts, [no_debug_info]},
-                    {relx, [{dev_mode, false},
+            {prod, [{relx, [{dev_mode, false},
                             {include_erts, true}]}]},
             {test, [{erl_opts, [{i, "test"}]}]}
 ]}.


### PR DESCRIPTION
This moves symbol stripping at the relx level instead of the prod profile. This fix an issue when trying to use dialyzer in a project which includes yaws as a library. With the previous code, symbols were stripped which led to dialyzer failing with 
`Could not get Core Erlang code for: base_path/_build/default/lib/yaws/ebin/XXXXX`

This fixes https://github.com/erlyaws/yaws/issues/501. 