### PR TITLE
Erlang/OTP 29.0-rc1 compilation warnings

### DIFF
--- a/src/json2.erl
+++ b/src/json2.erl
@@ -23,6 +23,8 @@
 -author("Gaspar Chilingarov <nm@web.am>, Gurgen Tumanyan <barbarian@armkb.com>").
 -author("Steve Vinoski <vinoski@ieee.org>").
 
+-compile('nowarn_deprecated_catch').
+
 %%% JavaScript Object Notation ("JSON", http://www.json.org) is a simple
 %%% data syntax meant as a lightweight alternative to other representations,
 %%% such as XML.  JSON is natively supported by JavaScript, but many

--- a/src/yaws.erl
+++ b/src/yaws.erl
@@ -8,6 +8,8 @@
 -module(yaws).
 -author('klacke@bluetail.com').
 
+-compile('nowarn_deprecated_catch').
+
 -include("../include/yaws.hrl").
 -include("../include/yaws_api.hrl").
 -include("yaws_appdeps.hrl").

--- a/src/yaws_api.erl
+++ b/src/yaws_api.erl
@@ -1168,7 +1168,8 @@ reformat_header(H, FormatFun) ->
 		   (Hdr, Acc) ->
 			[Hdr|Acc]
 		end, [],
-		lists:zf(fun({Hname, Str}) ->
+		lists:filtermap(
+                         fun({Hname, Str}) ->
 				 I =  FormatFun(Hname, Str),
 				 {true, I};
 			    (undefined) ->

--- a/src/yaws_api.erl
+++ b/src/yaws_api.erl
@@ -8,6 +8,8 @@
 -module(yaws_api).
 -author('klacke@hyber.org').
 
+-compile('nowarn_deprecated_catch').
+
 -include("../include/yaws.hrl").
 -include("../include/yaws_api.hrl").
 -include("yaws_debug.hrl").

--- a/src/yaws_appmod_dav.erl
+++ b/src/yaws_appmod_dav.erl
@@ -28,6 +28,8 @@
 
 -module(yaws_appmod_dav).
 
+-compile('nowarn_deprecated_catch').
+
 %% for appmod:
 -export([out/1]).
 

--- a/src/yaws_cgi.erl
+++ b/src/yaws_cgi.erl
@@ -2,6 +2,8 @@
 -author('carsten@codimi.de').
 -author('brunorijsman@hotmail.com').         %% Added support for FastCGI
 
+-compile('nowarn_deprecated_catch').
+
 -include("../include/yaws_api.hrl").
 -include("yaws_debug.hrl").
 -include("../include/yaws.hrl").

--- a/src/yaws_cgi.erl
+++ b/src/yaws_cgi.erl
@@ -375,7 +375,8 @@ build_env(Arg, Scriptfilename, Pathinfo, ExtraEnv, SC) ->
         Extra_CGI_Vars.
 
 other_headers(Headers) ->
-    lists:zf(fun({http_header,_,Var,_,Val}) ->
+    lists:filtermap(
+            fun({http_header,_,Var,_,Val}) ->
                      case tohttp(Var) of
                          "HTTP_PROXY" ->
                              %% See http://httpoxy.org/

--- a/src/yaws_config.erl
+++ b/src/yaws_config.erl
@@ -8,6 +8,7 @@
 -module(yaws_config).
 -author('klacke@bluetail.com').
 
+-compile('nowarn_deprecated_catch').
 
 -include("../include/yaws.hrl").
 -include("../include/yaws_api.hrl").

--- a/src/yaws_config.erl
+++ b/src/yaws_config.erl
@@ -3195,7 +3195,7 @@ ssl_start() ->
 %% Return {Pid, SC, Scs} or false
 %% Pairs is the pairs in yaws_server #state{}
 search_sconf(GC, NewSC, Pairs) ->
-    case lists:zf(
+    case lists:filtermap(
            fun({Pid, Scs = [SC|_]}) ->
                    case same_virt_srv(GC, NewSC, SC) of
                        true ->
@@ -3231,7 +3231,7 @@ search_group(GC, SC, Pairs) ->
                    end
            end,
 
-    lists:zf(Fun, Pairs).
+    lists:filtermap(Fun, Pairs).
 
 
 %% Return a new Pairs list with one SC updated
@@ -3251,7 +3251,7 @@ update_sconf(Gc, NewSc, Pos, Pairs) ->
 
 %% return a new pairs list with SC removed
 delete_sconf(Gc, OldSc, Pairs) ->
-    lists:zf(
+    lists:filtermap(
       fun({Pid, Scs}) ->
               case same_virt_srv(Gc, hd(Scs), OldSc) of
                   true ->

--- a/src/yaws_ctl.erl
+++ b/src/yaws_ctl.erl
@@ -11,6 +11,8 @@
 -module(yaws_ctl).
 -author('klacke@bluetail.com').
 
+-compile('nowarn_deprecated_catch').
+
 -include_lib("kernel/include/file.hrl").
 -include("../include/yaws.hrl").
 -include("../include/yaws_api.hrl").

--- a/src/yaws_debug.erl
+++ b/src/yaws_debug.erl
@@ -8,6 +8,8 @@
 -module(yaws_debug).
 -author('klacke@hyber.org').
 
+-compile('nowarn_deprecated_catch').
+
 -include("../include/yaws.hrl").
 -include("../include/yaws_api.hrl").
 -include("yaws_debug.hrl").

--- a/src/yaws_debug.erl
+++ b/src/yaws_debug.erl
@@ -205,7 +205,7 @@ xref([Dir]) ->
 
 
 pids() ->
-    lists:zf(
+    lists:filtermap(
       fun(P) ->
               case process_info(P) of
                   L when is_list(L) ->

--- a/src/yaws_jsonrpc.erl
+++ b/src/yaws_jsonrpc.erl
@@ -49,6 +49,8 @@
 -export([handler/2]).
 -export([handler_session/2, handler_session/3]).
 
+-compile('nowarn_deprecated_catch').
+
 %%-define(debug, 1).
 -include("yaws_debug.hrl").
 

--- a/src/yaws_log.erl
+++ b/src/yaws_log.erl
@@ -10,6 +10,7 @@
 -include_lib("kernel/include/file.hrl").
 -include_lib("kernel/include/inet.hrl").
 
+-compile('nowarn_deprecated_catch').
 
 -behaviour(gen_server).
 

--- a/src/yaws_logger.erl
+++ b/src/yaws_logger.erl
@@ -9,6 +9,7 @@
 -author('christopher@yakaz.com').
 -include_lib("kernel/include/file.hrl").
 
+-compile('nowarn_deprecated_catch').
 
 %% API
 -export([

--- a/src/yaws_ls.erl
+++ b/src/yaws_ls.erl
@@ -31,7 +31,7 @@ list_directory(Arg, CliSock, List, DirName, Req, DoAllZip) ->
 
     Descriptions = read_descriptions(DirName),
 
-    L0 = lists:zf(
+    L0 = lists:filtermap(
            fun(F) ->
                    File = DirName ++ [$/|F],
                    FI = file:read_file_info(File),
@@ -464,8 +464,8 @@ file_entry(_Err, _, _Name, _, _) ->
 
 trim(L,N) ->
     trim(L,N,[]).
-trim([_H1,_H2,_H3]=[H|T], 3=I, Acc) ->
-    trim(T, I-1, [H|Acc]);
+trim([H1,H2,H3], 3=I, Acc) ->
+    trim([H2,H3], I-1, [H1|Acc]);
 trim([H1,H2,H3|_T], 3=_I, Acc) when H1 < 128, H2 < 128, H3 < 128 ->
     lists:reverse(Acc) ++ "..&gt;";
 trim([H1,H2,H3|_T], 3=_I, [H0|Acc]) ->

--- a/src/yaws_ls.erl
+++ b/src/yaws_ls.erl
@@ -10,6 +10,8 @@
 -module(yaws_ls).
 -author('klacke@hyber.org').
 
+-compile('nowarn_deprecated_catch').
+
 -include("../include/yaws.hrl").
 -include("../include/yaws_api.hrl").
 -include("yaws_debug.hrl").

--- a/src/yaws_revproxy.erl
+++ b/src/yaws_revproxy.erl
@@ -7,6 +7,8 @@
 %%%-------------------------------------------------------------------
 -module(yaws_revproxy).
 
+-compile('nowarn_deprecated_catch').
+
 -include("../include/yaws.hrl").
 -include("../include/yaws_api.hrl").
 -include("yaws_debug.hrl").

--- a/src/yaws_rpc.erl
+++ b/src/yaws_rpc.erl
@@ -40,6 +40,8 @@
 -modified_by("Yariv Sadan <yarivvv@gmail.com>").
 -modified_by("Steve Vinoski <vinoski@ieee.org>").
 
+-compile('nowarn_deprecated_catch').
+
 -export([handler/2]).
 -export([handler_session/2, handler_session/3]).
 

--- a/src/yaws_rss.erl
+++ b/src/yaws_rss.erl
@@ -13,6 +13,8 @@
 
 -behaviour(gen_server).
 
+-compile('nowarn_deprecated_catch').
+
 %% External exports
 -export([start/0, start_link/0, open/1, open/2, close/0, close/2,
          insert/5, insert/6, insert/7, retrieve/2]).

--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -8,6 +8,8 @@
 -module(yaws_server).
 -author('klacke@hyber.org').
 
+-compile('nowarn_deprecated_catch').
+
 -behaviour(gen_server).
 -include("../include/yaws.hrl").
 -include("../include/yaws_api.hrl").

--- a/src/yaws_session_server.erl
+++ b/src/yaws_session_server.erl
@@ -8,6 +8,7 @@
 -module(yaws_session_server).
 -author('klacke@hyber.org').
 
+-compile('nowarn_deprecated_catch').
 
 -behaviour(gen_server).
 

--- a/src/yaws_shaper.erl
+++ b/src/yaws_shaper.erl
@@ -8,6 +8,7 @@
 -module(yaws_shaper).
 -author('christopher@yakaz.com').
 
+-compile('nowarn_deprecated_catch').
 
 -export([behaviour_info/1]).
 

--- a/src/yaws_soap_srv.erl
+++ b/src/yaws_soap_srv.erl
@@ -5,6 +5,8 @@
 %%%-------------------------------------------------------------------
 -module(yaws_soap_srv).
 
+-compile('nowarn_deprecated_catch').
+
 -behaviour(gen_server).
 
 %% API

--- a/src/yaws_sse.erl
+++ b/src/yaws_sse.erl
@@ -7,6 +7,8 @@
 -module(yaws_sse).
 -author('vinoski@ieee.org').
 
+-compile('nowarn_deprecated_catch').
+
 -export([headers/1,
          event/0, event/1,
          data/0, data/1, data/2,

--- a/src/yaws_vdir.erl
+++ b/src/yaws_vdir.erl
@@ -1,5 +1,7 @@
 -module(yaws_vdir).
 
+-compile('nowarn_deprecated_catch').
+
 -export([arg_rewrite/1]).
 
 -include("../include/yaws_api.hrl").

--- a/src/yaws_websockets.erl
+++ b/src/yaws_websockets.erl
@@ -11,6 +11,8 @@
 -author('jbothma@gmail.com').
 -behaviour(gen_server).
 
+-compile('nowarn_deprecated_catch').
+
 -include("../include/yaws.hrl").
 -include("../include/yaws_api.hrl").
 

--- a/src/yaws_xmlrpc.erl
+++ b/src/yaws_xmlrpc.erl
@@ -35,6 +35,8 @@
 -export([handler/2]).
 -export([handler_session/2, handler_session/3]).
 
+-compile('nowarn_deprecated_catch').
+
 %%-define(debug, 1).
 %%-include("../../yaws/src/yaws_debug.hrl").
 


### PR DESCRIPTION
I am not expecting that this PR is accepted as is since the usages of catch are not fixed and are just being ignored. But maybe it's good enough for some initial testing to be done with Erlang/OTP-29 and then the catch rewrite can be done later.

Fixes #506 